### PR TITLE
Fix leaderboard CF Pages build (chain build:data into build)

### DIFF
--- a/.github/workflows/leaderboard-build.yml
+++ b/.github/workflows/leaderboard-build.yml
@@ -49,10 +49,10 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
-      - name: Build leaderboard data shards
-        run: pnpm -F @qg/leaderboard build:data
-
       - name: Build leaderboard site
+        # The `build` script chains build:data (TypeScript shard generator)
+        # with astro build, so a single command produces a complete site.
+        # Same script Cloudflare Pages runs.
         run: pnpm -F @qg/leaderboard build
 
       - name: Upload dist artifact

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Workspace root for QueryGym websites (leaderboard + marketing). Not published.",
   "scripts": {
-    "build:leaderboard": "pnpm -F @qg/leaderboard build:data && pnpm -F @qg/leaderboard build",
+    "build:leaderboard": "pnpm -F @qg/leaderboard build",
     "dev:leaderboard": "pnpm -F @qg/leaderboard dev",
     "build:site": "pnpm -F @qg/site build",
     "dev:site": "pnpm -F @qg/site dev"

--- a/reproducibility/site/package.json
+++ b/reproducibility/site/package.json
@@ -6,7 +6,8 @@
   "description": "Astro site for leaderboard.querygym.com — SIGIR reproducibility leaderboard.",
   "scripts": {
     "build:data": "tsx scripts/build-data.ts",
-    "build": "astro build",
+    "build": "tsx scripts/build-data.ts && astro build",
+    "build:astro-only": "astro build",
     "dev": "astro dev",
     "preview": "astro preview",
     "check": "astro check"


### PR DESCRIPTION
## Symptom

Cloudflare Pages build for the leaderboard project failed with:

\`\`\`
✗ Build failed in 1.03s
Could not resolve "../../data/datasets.json" from "src/pages/datasets/index.astro"
\`\`\`

## Cause

The CF Pages project (default config) ran \`npm run build\`, which mapped to the package's \`build\` script: \`astro build\`. But that command alone doesn't generate the \`src/data/\*.json\` shards — those come from \`build-data.ts\`, run via the separate \`build:data\` script.

\`src/data/\` is gitignored (correctly — it's derived), so without \`build:data\` the shards don't exist and Astro fails to import them.

## Fix

Chain them inside the package's own \`build\` script:

\`\`\`json
"build": "tsx scripts/build-data.ts && astro build"
\`\`\`

So \`pnpm -F @qg/leaderboard build\` (or \`npm run build\` in CF Pages, or the same in the GitHub Actions workflow) now produces a complete site in one command. The CI workflow is simplified to a single \`Build leaderboard site\` step.

\`build:data\` is preserved as a standalone script for anyone who wants to regenerate just the shards. \`build:astro-only\` is added as an escape hatch for debugging Astro without the data step.

## Test plan

- [x] \`rm -rf reproducibility/site/{dist,src/data}\` then \`pnpm -F @qg/leaderboard build\` → 37 pages built.
- [ ] CF Pages re-deploys with the simpler default \`npm run build\` and succeeds.
- [ ] CI on this PR runs \`Leaderboard Build\` and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)