### PR TITLE
Add SEO surface to querygym.com + restore home-page logo

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,9 @@ importers:
 
   web/site:
     dependencies:
+      '@astrojs/sitemap':
+        specifier: ^3.7.2
+        version: 3.7.2
       '@astrojs/tailwind':
         specifier: ^5.1.5
         version: 5.1.5(astro@5.18.1(@types/node@20.19.39)(jiti@1.21.7)(rollup@4.60.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
@@ -102,6 +105,9 @@ packages:
   '@astrojs/prism@3.3.0':
     resolution: {integrity: sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
+
+  '@astrojs/sitemap@3.7.2':
+    resolution: {integrity: sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==}
 
   '@astrojs/solid-js@5.1.3':
     resolution: {integrity: sha512-KxfYt4y1d7BuSw6EsN1EaPoGYsIES7bEI6AtTbncuabRUUMZs+mOWOeOdmgnwVLj+jbNbhBjUZsqr77eUviZdw==}
@@ -1114,8 +1120,14 @@ packages:
   '@types/node@20.19.39':
     resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
 
+  '@types/node@24.12.2':
+    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
   '@types/papaparse@5.5.2':
     resolution: {integrity: sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==}
+
+  '@types/sax@1.2.7':
+    resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -2121,6 +2133,11 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  sitemap@9.0.1:
+    resolution: {integrity: sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==}
+    engines: {node: '>=20.19.5', npm: '>=10.8.2'}
+    hasBin: true
+
   smol-toml@1.6.1:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
@@ -2139,6 +2156,9 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  stream-replace-string@2.0.0:
+    resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2251,6 +2271,9 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   undici@7.24.8:
     resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
@@ -2519,6 +2542,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -2559,6 +2585,12 @@ snapshots:
   '@astrojs/prism@3.3.0':
     dependencies:
       prismjs: 1.30.0
+
+  '@astrojs/sitemap@3.7.2':
+    dependencies:
+      sitemap: 9.0.1
+      stream-replace-string: 2.0.0
+      zod: 4.3.6
 
   '@astrojs/solid-js@5.1.3(@types/node@20.19.39)(jiti@1.21.7)(solid-js@1.9.12)(tsx@4.21.0)(yaml@2.8.3)':
     dependencies:
@@ -3303,7 +3335,15 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@24.12.2':
+    dependencies:
+      undici-types: 7.16.0
+
   '@types/papaparse@5.5.2':
+    dependencies:
+      '@types/node': 20.19.39
+
+  '@types/sax@1.2.7':
     dependencies:
       '@types/node': 20.19.39
 
@@ -4703,6 +4743,13 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  sitemap@9.0.1:
+    dependencies:
+      '@types/node': 24.12.2
+      '@types/sax': 1.2.7
+      arg: 5.0.2
+      sax: 1.6.0
+
   smol-toml@1.6.1: {}
 
   solid-js@1.9.12:
@@ -4723,6 +4770,8 @@ snapshots:
   source-map-js@1.2.1: {}
 
   space-separated-tokens@2.0.2: {}
+
+  stream-replace-string@2.0.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -4853,6 +4902,8 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@6.21.0: {}
+
+  undici-types@7.16.0: {}
 
   undici@7.24.8: {}
 
@@ -5063,5 +5114,7 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zod@4.3.6: {}
 
   zwitch@2.0.4: {}

--- a/web/site/astro.config.mjs
+++ b/web/site/astro.config.mjs
@@ -1,10 +1,27 @@
 import { defineConfig } from "astro/config";
 import tailwind from "@astrojs/tailwind";
+import sitemap from "@astrojs/sitemap";
 
 export default defineConfig({
   site: "https://querygym.com",
   output: "static",
-  integrations: [tailwind({ applyBaseStyles: false })],
+  integrations: [
+    tailwind({ applyBaseStyles: false }),
+    sitemap({
+      // Daily change frequency for content, weekly for the rest. Defaults are
+      // conservative; bump priority for the home page so search engines treat
+      // it as the canonical entry point.
+      changefreq: "weekly",
+      priority: 0.7,
+      lastmod: new Date(),
+      serialize(item) {
+        if (item.url === "https://querygym.com/") {
+          return { ...item, priority: 1.0, changefreq: "weekly" };
+        }
+        return item;
+      },
+    }),
+  ],
   vite: {
     ssr: {
       noExternal: ["@qg/shared"],

--- a/web/site/package.json
+++ b/web/site/package.json
@@ -11,14 +11,15 @@
     "check": "astro check"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.7.2",
+    "@astrojs/tailwind": "^5.1.5",
     "@qg/shared": "workspace:*",
     "astro": "^5.0.0",
-    "@astrojs/tailwind": "^5.1.5",
     "tailwindcss": "^3.4.0"
   },
   "devDependencies": {
+    "@types/node": "^20.0.0",
     "typescript": "^5.6.0",
-    "wrangler": "^4.0.0",
-    "@types/node": "^20.0.0"
+    "wrangler": "^4.0.0"
   }
 }

--- a/web/site/public/robots.txt
+++ b/web/site/public/robots.txt
@@ -1,0 +1,5 @@
+# querygym.com — open to all well-behaved crawlers.
+User-agent: *
+Allow: /
+
+Sitemap: https://querygym.com/sitemap-index.xml

--- a/web/site/src/layouts/Default.astro
+++ b/web/site/src/layouts/Default.astro
@@ -8,9 +8,29 @@ interface Props {
   description?: string;
   /** Hide the gradient header (used for hero pages that draw their own). */
   bareHeader?: boolean;
+  /** Optional 1200×630 PNG/JPG path; defaults to the logo. Override per page when relevant. */
+  ogImage?: string;
+  /** Explicit Open Graph type (e.g. "article" for cite, "website" for everything else). */
+  ogType?: "website" | "article";
+  /** Optional JSON-LD structured-data string emitted into <head>. */
+  jsonLd?: string;
 }
 
-const { title, description, bareHeader = false } = Astro.props;
+const {
+  title,
+  description,
+  bareHeader = false,
+  ogImage = "/querygym-logo.png",
+  ogType = "website",
+  jsonLd,
+} = Astro.props;
+
+const SITE = "https://querygym.com";
+
+// Resolve the canonical URL from the current request when available, falling
+// back to the configured site root for the homepage.
+const canonical = new URL(Astro.url.pathname, SITE).toString();
+const ogImageAbsolute = new URL(ogImage, SITE).toString();
 
 const navLinks = [
   { label: "Install", href: "/install" },
@@ -20,6 +40,11 @@ const navLinks = [
   { label: "Docs", href: "https://querygym.readthedocs.io", external: true },
   { label: "Dashboard ↗", href: "https://dashboard.querygym.com", external: true },
 ];
+
+const fullTitle = `${title} — QueryGym`;
+const metaDescription =
+  description ??
+  "QueryGym is an open-source toolkit for reproducible LLM-based query reformulation in information retrieval.";
 ---
 
 <!doctype html>
@@ -27,12 +52,34 @@ const navLinks = [
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>{title} — QueryGym</title>
-    {description && <meta name="description" content={description} />}
-    <meta property="og:title" content={`${title} — QueryGym`} />
-    {description && <meta property="og:description" content={description} />}
-    <meta property="og:image" content="/querygym-logo.png" />
+    <meta name="theme-color" content="#667eea" />
+    <meta name="generator" content={Astro.generator} />
+
+    <title>{fullTitle}</title>
+    <meta name="description" content={metaDescription} />
+    <meta name="author" content="ls3-lab" />
+    <link rel="canonical" href={canonical} />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content={ogType} />
+    <meta property="og:site_name" content="QueryGym" />
+    <meta property="og:title" content={fullTitle} />
+    <meta property="og:description" content={metaDescription} />
+    <meta property="og:url" content={canonical} />
+    <meta property="og:image" content={ogImageAbsolute} />
+    <meta property="og:image:alt" content="QueryGym logo" />
+    <meta property="og:locale" content="en_US" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={fullTitle} />
+    <meta name="twitter:description" content={metaDescription} />
+    <meta name="twitter:image" content={ogImageAbsolute} />
+
     <link rel="icon" type="image/png" href="/querygym-logo.png" />
+    <link rel="sitemap" href="/sitemap-index.xml" />
+
+    {jsonLd && <script type="application/ld+json" set:html={jsonLd} />}
   </head>
   <body class="min-h-screen bg-qg-bg text-qg-fg">
     {

--- a/web/site/src/pages/cite.astro
+++ b/web/site/src/pages/cite.astro
@@ -20,9 +20,36 @@ const sigirBibtex = `@inproceedings{querygym2026reproducibility,
   year={2026},
   note={Reproducibility Track},
 }`;
+
+// JSON-LD ScholarlyArticle for the WWW 2026 Demos paper. Search engines use
+// this to surface the paper as a research artifact in scholar-aware results.
+const jsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "ScholarlyArticle",
+  name: "QueryGym: A Toolkit for Reproducible LLM-Based Query Reformulation",
+  url: "https://arxiv.org/abs/2511.15996",
+  identifier: "arXiv:2511.15996",
+  datePublished: "2025-11-20",
+  inLanguage: "en",
+  isAccessibleForFree: true,
+  publisher: { "@type": "Organization", name: "arXiv" },
+  author: [
+    { "@type": "Person", name: "Amin Bigdeli" },
+    { "@type": "Person", name: "Radin Hamidi Rad" },
+    { "@type": "Person", name: "Mert Incesu" },
+    { "@type": "Person", name: "Negar Arabzadeh" },
+    { "@type": "Person", name: "Charles L. A. Clarke" },
+    { "@type": "Person", name: "Ebrahim Bagheri" },
+  ],
+});
 ---
 
-<Default title="Cite" description="How to cite QueryGym in research papers.">
+<Default
+  title="Cite"
+  description="How to cite QueryGym in research papers — BibTeX for the WWW 2026 Demos paper and the SIGIR 2026 Reproducibility Track paper."
+  ogType="article"
+  jsonLd={jsonLd}
+>
   <section class="qg-section !py-12">
     <h1 class="text-3xl font-bold md:text-4xl">Cite QueryGym</h1>
     <p class="mt-3 max-w-2xl text-qg-fg-muted">

--- a/web/site/src/pages/index.astro
+++ b/web/site/src/pages/index.astro
@@ -5,12 +5,51 @@ import FeatureGrid from "../components/FeatureGrid.astro";
 import EcosystemMap from "../components/EcosystemMap.astro";
 import CodeBlock from "../components/CodeBlock.astro";
 import MethodGrid from "../components/MethodGrid.astro";
+
+// JSON-LD: SoftwareApplication describing the QueryGym toolkit, plus a
+// nested Organization for the lab. Helps Google build a richer knowledge
+// panel and link the surfaces (site, dashboard, repo, leaderboard).
+const jsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "SoftwareApplication",
+      "@id": "https://querygym.com/#software",
+      name: "QueryGym",
+      applicationCategory: "DeveloperApplication",
+      operatingSystem: "Cross-platform",
+      url: "https://querygym.com",
+      description:
+        "An open-source toolkit for reproducible LLM-based query reformulation in information retrieval.",
+      license: "https://www.apache.org/licenses/LICENSE-2.0",
+      programmingLanguage: "Python",
+      codeRepository: "https://github.com/ls3-lab/QueryGym",
+      downloadUrl: "https://pypi.org/project/querygym/",
+      offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+      sameAs: [
+        "https://github.com/ls3-lab/QueryGym",
+        "https://pypi.org/project/querygym/",
+        "https://leaderboard.querygym.com",
+        "https://querygym.readthedocs.io",
+        "https://arxiv.org/abs/2511.15996",
+      ],
+      author: { "@id": "https://querygym.com/#org" },
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://querygym.com/#org",
+      name: "ls3-lab",
+      url: "https://querygym.com",
+      sameAs: ["https://github.com/ls3-lab"],
+    },
+  ],
+});
 ---
 
 <Default
   title="LLM-based Query Reformulation Toolkit"
   description="QueryGym is an open-source toolkit for reproducible LLM-based query reformulation in information retrieval."
-  bareHeader
+  jsonLd={jsonLd}
 >
   <Hero />
 


### PR DESCRIPTION
## Summary

Two things in one PR:

1. **SEO** — proper meta tags, sitemap, robots.txt, and JSON-LD structured data so search engines can index, rank, and surface the site.
2. **Bug fix (user-reported)** — the homepage was missing the QueryGym logo because \`bareHeader\` was hiding the entire shared header. Removed; the gradient header (with logo + nav) now renders above the hero panel.

## Layout meta (\`web/site/src/layouts/Default.astro\`)

| Tag | Why |
|---|---|
| \`<link rel="canonical">\` | Tells crawlers the canonical URL when there are tracking params or alt routes. |
| \`og:type\`, \`og:site_name\`, \`og:url\`, \`og:image:alt\`, \`og:locale\` | Richer Open Graph cards on Slack/Twitter/LinkedIn previews. |
| Twitter Card (\`summary_large_image\`) | First-class Twitter previews. |
| \`theme-color\` | Matches gradient start (\`#667eea\`) — used by mobile browsers' chrome. |
| \`author\` | Identifies ls3-lab as the maintainer. |
| \`<link rel="sitemap">\` | Discoverability for crawlers that look at it. |
| Per-page \`ogType\` + \`jsonLd\` props | Cite is \`article\`; home + cite get JSON-LD. |

## Sitemap

\`@astrojs/sitemap\` integration (Astro official). Generates \`sitemap-index.xml\` + \`sitemap-0.xml\` at build time. Home priority 1.0; rest 0.7. Weekly changefreq.

## robots.txt

\`Allow: /\` + sitemap URL. Open to all well-behaved crawlers.

## Structured data (JSON-LD)

- **Home**: \`SoftwareApplication\` + \`Organization\`. Has \`sameAs\` linking GitHub, PyPI, leaderboard, RTD, arXiv — helps Google build a unified knowledge panel that connects the four ecosystem surfaces.
- **/cite**: \`ScholarlyArticle\` for the WWW 2026 demo paper. Author list + arXiv identifier.

## Bug fix: missing logo on home

\`web/site/src/pages/index.astro\` previously passed \`bareHeader\` to \`Default\` so the Hero could draw its own gradient panel. That also hid the shared header (and therefore the logo + nav). Removing \`bareHeader\` makes the standard header render above the hero — both share the same gradient, so visually it's a continuous bar with no seam.

## Test plan

- [x] \`pnpm -F @qg/site build\` → 6 pages + sitemap-index.xml + sitemap-0.xml + robots.txt.
- [x] Home renders the QueryGym logo in the header again.
- [x] \`<head>\` on home contains: canonical, og:type/url/site_name/image-alt, twitter:card, theme-color, JSON-LD with SoftwareApplication.
- [x] \`<head>\` on /cite contains: og:type=article, JSON-LD with ScholarlyArticle.
- [x] \`/sitemap-index.xml\` lists 6 URLs; home has priority 1.0.
- [x] \`/robots.txt\` Allow: /.
- [ ] CF Pages preview deploy renders correctly.
- [ ] Validate JSON-LD with [Schema Markup Validator](https://validator.schema.org/) post-deploy.
- [ ] Submit sitemap to Google Search Console once querygym.com is verified there.

## Follow-up (not in this PR)

- A proper 1200×630 OG card image (currently the logo PNG is used). Visual quality + brand wordmark on a gradient would render better when shared on social.
- \`@astrojs/sitemap\` for the leaderboard project too (separate domain → separate sitemap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)