### PR TITLE
Add Google Analytics 4 to both sites (env-var driven)

### DIFF
--- a/reproducibility/site/src/layouts/Default.astro
+++ b/reproducibility/site/src/layouts/Default.astro
@@ -2,6 +2,7 @@
 import "../styles/global.css";
 import Header from "@qg/shared/components/Header.astro";
 import Footer from "@qg/shared/components/Footer.astro";
+import GoogleAnalytics from "@qg/shared/components/GoogleAnalytics.astro";
 
 interface Props {
   title: string;
@@ -27,6 +28,8 @@ const navLinks = [
     <title>{title} — QueryGym Leaderboard</title>
     {description && <meta name="description" content={description} />}
     <link rel="icon" type="image/png" href="/querygym-logo.png" />
+
+    <GoogleAnalytics />
   </head>
   <body class="min-h-screen bg-qg-bg text-qg-fg">
     <Header

--- a/web/shared/components/GoogleAnalytics.astro
+++ b/web/shared/components/GoogleAnalytics.astro
@@ -1,0 +1,37 @@
+---
+/**
+ * Google Analytics 4 (gtag.js) injector.
+ *
+ * Reads the measurement ID from `import.meta.env.PUBLIC_GA_MEASUREMENT_ID`
+ * at build time. Astro inlines `PUBLIC_*` env vars into the static output,
+ * so each Cloudflare Pages project can have its own ID set via the project's
+ * "Environment variables" pane (querygym-site → G-XXXXXXXXXX,
+ * querygym-leaderboard → G-YYYYYYYYYY).
+ *
+ * If the env var is absent (e.g. local dev, preview branches that don't set
+ * it), nothing renders and no analytics requests fire — keeps `pnpm dev` and
+ * preview branches silent.
+ *
+ * No consent banner here. Add one when targeting EU traffic at scale; until
+ * then, GA4's default IP anonymization is in effect.
+ */
+const id = import.meta.env.PUBLIC_GA_MEASUREMENT_ID as string | undefined;
+
+// Build the inline script as a string and feed it via set:html so Astro
+// doesn't try to parse the function-body curly braces as JSX expressions.
+const inlineScript = id
+  ? `window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', ${JSON.stringify(id)});`
+  : "";
+---
+
+{
+  id && (
+    <>
+      <script is:inline async src={`https://www.googletagmanager.com/gtag/js?id=${id}`} />
+      <script is:inline set:html={inlineScript} />
+    </>
+  )
+}

--- a/web/site/src/layouts/Default.astro
+++ b/web/site/src/layouts/Default.astro
@@ -2,6 +2,7 @@
 import "../styles/global.css";
 import Header from "@qg/shared/components/Header.astro";
 import Footer from "@qg/shared/components/Footer.astro";
+import GoogleAnalytics from "@qg/shared/components/GoogleAnalytics.astro";
 
 interface Props {
   title: string;
@@ -80,6 +81,8 @@ const metaDescription =
     <link rel="sitemap" href="/sitemap-index.xml" />
 
     {jsonLd && <script type="application/ld+json" set:html={jsonLd} />}
+
+    <GoogleAnalytics />
   </head>
   <body class="min-h-screen bg-qg-bg text-qg-fg">
     {


### PR DESCRIPTION
## Summary

Adds GA4 (gtag.js) to both \`querygym.com\` and \`leaderboard.querygym.com\`. The measurement ID isn't hardcoded — each Cloudflare Pages project sets its own ID via the dashboard's **Environment variables** pane:

| CF Pages project | Env var | Value |
|---|---|---|
| \`querygym-site\` | \`PUBLIC_GA_MEASUREMENT_ID\` | your G-XXXXXXXXXX |
| \`querygym-leaderboard\` | \`PUBLIC_GA_MEASUREMENT_ID\` | your G-YYYYYYYYYY (separate property/stream) |

If the env var is unset (local dev, fork PRs, preview branches without prod env), nothing renders — no analytics requests fire. Keeps dev environments silent.

## How it works

- New shared component \`web/shared/components/GoogleAnalytics.astro\`
- Reads \`import.meta.env.PUBLIC_GA_MEASUREMENT_ID\` at build time (Astro inlines \`PUBLIC_*\` into the static output).
- Renders the standard gtag.js script + a small inline config call.
- Wired into both Default layouts.

The inline config script is built as a string and emitted via \`set:html\` so Astro doesn't try to parse JS function-body curly braces as JSX expressions.

## Stacked on #11

This PR is based on \`chore/site-seo\` (PR #11). Merge order:
1. Merge #11 first (SEO surface + logo fix).
2. Then re-target this PR's base to \`main\` (GitHub does this automatically) and merge.

After #11 merges this PR's diff will narrow to just the three GA-related files.

## Test plan

- [x] No env var: build succeeds; \`grep googletagmanager dist/index.html\` returns 0 on both sites.
- [x] \`PUBLIC_GA_MEASUREMENT_ID=G-TEST123ABC pnpm -F @qg/site build\`: gtag.js script with the test ID renders in \`<head>\`.
- [x] Same for the leaderboard.
- [ ] CF Pages env vars set in dashboard before re-deploy.
- [ ] After deploy: GA4 Realtime report shows traffic from \`querygym.com\` and \`leaderboard.querygym.com\`.

## Privacy notes

- GA4's default IP anonymization is in effect.
- No consent banner here. If EU traffic becomes a real concern, add a Cookie-banner component (or migrate to Cloudflare Web Analytics, which doesn't require consent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)