### PR TITLE
Polish: drop hero pill, simplify Paper label, soften cite copy + re-apply GA4

### DIFF
--- a/reproducibility/site/src/layouts/Default.astro
+++ b/reproducibility/site/src/layouts/Default.astro
@@ -2,6 +2,7 @@
 import "../styles/global.css";
 import Header from "@qg/shared/components/Header.astro";
 import Footer from "@qg/shared/components/Footer.astro";
+import GoogleAnalytics from "@qg/shared/components/GoogleAnalytics.astro";
 
 interface Props {
   title: string;
@@ -27,6 +28,8 @@ const navLinks = [
     <title>{title} — QueryGym Leaderboard</title>
     {description && <meta name="description" content={description} />}
     <link rel="icon" type="image/png" href="/querygym-logo.png" />
+
+    <GoogleAnalytics />
   </head>
   <body class="min-h-screen bg-qg-bg text-qg-fg">
     <Header

--- a/web/shared/components/Footer.astro
+++ b/web/shared/components/Footer.astro
@@ -22,7 +22,7 @@ const baseLinks: FooterLink[] = [
   { label: "GitHub", href: "https://github.com/ls3-lab/QueryGym" },
   { label: "Docs", href: "https://querygym.readthedocs.io" },
   { label: "Dashboard", href: "https://dashboard.querygym.com" },
-  { label: "Paper (WWW 2026)", href: "https://arxiv.org/abs/2511.15996" },
+  { label: "Paper", href: "https://arxiv.org/abs/2511.15996" },
 ];
 ---
 

--- a/web/shared/components/GoogleAnalytics.astro
+++ b/web/shared/components/GoogleAnalytics.astro
@@ -1,0 +1,37 @@
+---
+/**
+ * Google Analytics 4 (gtag.js) injector.
+ *
+ * Reads the measurement ID from `import.meta.env.PUBLIC_GA_MEASUREMENT_ID`
+ * at build time. Astro inlines `PUBLIC_*` env vars into the static output,
+ * so each Cloudflare Pages project can have its own ID set via the project's
+ * "Environment variables" pane (querygym-site → G-XXXXXXXXXX,
+ * querygym-leaderboard → G-YYYYYYYYYY).
+ *
+ * If the env var is absent (e.g. local dev, preview branches that don't set
+ * it), nothing renders and no analytics requests fire — keeps `pnpm dev` and
+ * preview branches silent.
+ *
+ * No consent banner here. Add one when targeting EU traffic at scale; until
+ * then, GA4's default IP anonymization is in effect.
+ */
+const id = import.meta.env.PUBLIC_GA_MEASUREMENT_ID as string | undefined;
+
+// Build the inline script as a string and feed it via set:html so Astro
+// doesn't try to parse the function-body curly braces as JSX expressions.
+const inlineScript = id
+  ? `window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', ${JSON.stringify(id)});`
+  : "";
+---
+
+{
+  id && (
+    <>
+      <script is:inline async src={`https://www.googletagmanager.com/gtag/js?id=${id}`} />
+      <script is:inline set:html={inlineScript} />
+    </>
+  )
+}

--- a/web/site/src/components/Hero.astro
+++ b/web/site/src/components/Hero.astro
@@ -9,10 +9,7 @@
 <section class="qg-gradient relative overflow-hidden text-white">
   <div class="mx-auto grid max-w-6xl gap-10 px-4 py-20 md:grid-cols-[1.1fr_1fr] md:items-center md:py-28">
     <div>
-      <span class="qg-pill !border-white/20 !bg-white/10 !text-white/85">
-        Open source · WWW 2026 · SIGIR 2026 Reproducibility
-      </span>
-      <h1 class="mt-5 text-4xl font-bold leading-tight md:text-5xl">
+      <h1 class="text-4xl font-bold leading-tight md:text-5xl">
         Reproducible query reformulation, powered by LLMs.
       </h1>
       <p class="mt-5 max-w-xl text-base text-white/85 md:text-lg">

--- a/web/site/src/layouts/Default.astro
+++ b/web/site/src/layouts/Default.astro
@@ -2,6 +2,7 @@
 import "../styles/global.css";
 import Header from "@qg/shared/components/Header.astro";
 import Footer from "@qg/shared/components/Footer.astro";
+import GoogleAnalytics from "@qg/shared/components/GoogleAnalytics.astro";
 
 interface Props {
   title: string;
@@ -80,6 +81,8 @@ const metaDescription =
     <link rel="sitemap" href="/sitemap-index.xml" />
 
     {jsonLd && <script type="application/ld+json" set:html={jsonLd} />}
+
+    <GoogleAnalytics />
   </head>
   <body class="min-h-screen bg-qg-bg text-qg-fg">
     {

--- a/web/site/src/pages/cite.astro
+++ b/web/site/src/pages/cite.astro
@@ -54,8 +54,8 @@ const jsonLd = JSON.stringify({
     <h1 class="text-3xl font-bold md:text-4xl">Cite QueryGym</h1>
     <p class="mt-3 max-w-2xl text-qg-fg-muted">
       Two papers back QueryGym. Use the toolkit citation if you're using the
-      library; add the reproducibility citation if you're comparing against
-      the SIGIR 2026 leaderboard numbers.
+      library; add the reproducibility citation if you're referring to the
+      SIGIR 2026 leaderboard numbers.
     </p>
 
     <div class="mt-8 grid gap-4 md:grid-cols-2">


### PR DESCRIPTION
## Summary

Three copy edits + a recovery of the GA4 component that was orphaned during the PR #11/#12 merge sequence.

### Copy edits

| Where | Before | After |
|---|---|---|
| **Homepage hero** | \`Open source · WWW 2026 · SIGIR 2026 Reproducibility\` pill | _(removed entirely; h1 now sits at top of block)_ |
| **Footer → Project** | \`Paper (WWW 2026)\` | \`Paper\` |
| **/cite intro** | "…if you're **comparing against** the SIGIR 2026 leaderboard numbers." | "…if you're **referring to** the SIGIR 2026 leaderboard numbers." |

### GA4 re-apply

PR #12 merged into \`chore/site-seo\` (its base) rather than \`main\`. When PR #11 merged into main, only the SEO commit landed — the GA component was orphaned. Cherry-picked \`cf46b56\` so GA4 is back. Cloudflare Web Analytics is enabled separately in the CF dashboard (no code), so both run side-by-side.

## Operator follow-up (CF dashboard)

For each CF Pages project (\`querygym-site\`, \`querygym-leaderboard\`):
1. **Web Analytics** → Enable.
2. **Settings → Environment variables → Production**: \`PUBLIC_GA_MEASUREMENT_ID = G-XXXXXXXXXX\` (different value per site).
3. Trigger a redeploy.

## Test plan

- [x] \`pnpm -F @qg/site build\` → 6 pages.
- [x] Homepage: pill no longer in markup.
- [x] Footer: link reads \`Paper\`.
- [x] /cite copy: \`referring to\`.
- [x] GA4 component present in both layouts (renders only when env var set).
- [ ] After CF redeploy: GA4 Realtime + CF Web Analytics dashboards both show traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)