### PR TITLE
Add sitemap + robots.txt to leaderboard.querygym.com

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
 
   reproducibility/site:
     dependencies:
+      '@astrojs/sitemap':
+        specifier: ^3.7.2
+        version: 3.7.2
       '@astrojs/solid-js':
         specifier: ^5.0.0
         version: 5.1.3(@types/node@20.19.39)(jiti@1.21.7)(solid-js@1.9.12)(tsx@4.21.0)(yaml@2.8.3)

--- a/reproducibility/site/astro.config.mjs
+++ b/reproducibility/site/astro.config.mjs
@@ -1,11 +1,33 @@
 import { defineConfig } from "astro/config";
 import tailwind from "@astrojs/tailwind";
 import solid from "@astrojs/solid-js";
+import sitemap from "@astrojs/sitemap";
 
 export default defineConfig({
   site: "https://leaderboard.querygym.com",
   output: "static",
-  integrations: [tailwind({ applyBaseStyles: false }), solid()],
+  integrations: [
+    tailwind({ applyBaseStyles: false }),
+    solid(),
+    sitemap({
+      changefreq: "weekly",
+      priority: 0.5,
+      lastmod: new Date(),
+      serialize(item) {
+        // Home page is the canonical entry point.
+        if (item.url === "https://leaderboard.querygym.com/") {
+          return { ...item, priority: 1.0, changefreq: "weekly" };
+        }
+        // Per-run detail pages are mostly internal-link targets — give them
+        // lower priority so search engines focus on the dataset/method/model
+        // index pages.
+        if (item.url.startsWith("https://leaderboard.querygym.com/runs/")) {
+          return { ...item, priority: 0.3, changefreq: "monthly" };
+        }
+        return item;
+      },
+    }),
+  ],
   vite: {
     ssr: {
       // Needed because we read CSV/YAML at build time from outside the project root.

--- a/reproducibility/site/package.json
+++ b/reproducibility/site/package.json
@@ -13,22 +13,23 @@
     "check": "astro check"
   },
   "dependencies": {
-    "@qg/shared": "workspace:*",
-    "astro": "^5.0.0",
-    "@astrojs/tailwind": "^5.1.5",
+    "@astrojs/sitemap": "^3.7.2",
     "@astrojs/solid-js": "^5.0.0",
-    "solid-js": "^1.9.0",
+    "@astrojs/tailwind": "^5.1.5",
+    "@qg/shared": "workspace:*",
     "@tanstack/solid-table": "^8.20.0",
-    "tailwindcss": "^3.4.0",
+    "astro": "^5.0.0",
+    "js-yaml": "^4.1.0",
     "papaparse": "^5.4.1",
-    "js-yaml": "^4.1.0"
+    "solid-js": "^1.9.0",
+    "tailwindcss": "^3.4.0"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^20.0.0",
+    "@types/papaparse": "^5.3.15",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0",
-    "wrangler": "^4.0.0",
-    "@types/papaparse": "^5.3.15",
-    "@types/js-yaml": "^4.0.9",
-    "@types/node": "^20.0.0"
+    "wrangler": "^4.0.0"
   }
 }

--- a/reproducibility/site/public/robots.txt
+++ b/reproducibility/site/public/robots.txt
@@ -1,0 +1,5 @@
+# leaderboard.querygym.com — open to all well-behaved crawlers.
+User-agent: *
+Allow: /
+
+Sitemap: https://leaderboard.querygym.com/sitemap-index.xml

--- a/reproducibility/site/src/layouts/Default.astro
+++ b/reproducibility/site/src/layouts/Default.astro
@@ -29,6 +29,7 @@ const navLinks = [
     <title>{title} — QueryGym Leaderboard</title>
     {description && <meta name="description" content={description} />}
     <link rel="icon" type="image/png" href="/querygym-logo.png" />
+    <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap-index.xml" />
 
     <GoogleAnalytics />
   </head>


### PR DESCRIPTION
## Summary

Mirrors the SEO surface that querygym.com already has, on the leaderboard side.

- \`@astrojs/sitemap\` integration in \`reproducibility/site/astro.config.mjs\`. Home priority 1.0; dataset/method/model index pages 0.5; run-detail pages 0.3 monthly (mostly internal-link targets — let search engines focus on the index pages).
- \`reproducibility/site/public/robots.txt\` with the standard "Allow all + sitemap pointer" shape.
- \`<link rel="sitemap">\` in \`reproducibility/site/src/layouts/Default.astro\` for browser discoverability.

Generates **37 URLs** on the current empty-results state (1 home + 32 per-dataset + datasets/methods/models index + about). Shard count grows as runs land via \`submit_run.py\`.

## Where each robots.txt lives

Each origin needs its own \`robots.txt\` in that site's \`public/\`:
- \`querygym.com/robots.txt\` → \`web/site/public/robots.txt\` (existed already)
- \`leaderboard.querygym.com/robots.txt\` → \`reproducibility/site/public/robots.txt\` (added in this PR)

## Stacked

Base is \`chore/nav-and-sitemap-stacked\` (PR #14), which is in turn stacked on \`chore/copy-polish\` (PR #13). Once all three merge in order, this PR's diff narrows to just the leaderboard files.

## Test plan

- [x] \`pnpm -F @qg/leaderboard build\` succeeds.
- [x] \`dist/sitemap-index.xml\` and \`dist/sitemap-0.xml\` generated.
- [x] \`dist/robots.txt\` present, points at sitemap-index.
- [x] sitemap-0.xml contains 37 \`<loc>\` entries.
- [ ] After deploy: \`https://leaderboard.querygym.com/sitemap-index.xml\` resolves; submit to GSC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)