### PR TITLE
Recover orphaned PRs #14 + #15 (nav links + leaderboard sitemap)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
 
   reproducibility/site:
     dependencies:
+      '@astrojs/sitemap':
+        specifier: ^3.7.2
+        version: 3.7.2
       '@astrojs/solid-js':
         specifier: ^5.0.0
         version: 5.1.3(@types/node@20.19.39)(jiti@1.21.7)(solid-js@1.9.12)(tsx@4.21.0)(yaml@2.8.3)

--- a/reproducibility/site/astro.config.mjs
+++ b/reproducibility/site/astro.config.mjs
@@ -1,11 +1,33 @@
 import { defineConfig } from "astro/config";
 import tailwind from "@astrojs/tailwind";
 import solid from "@astrojs/solid-js";
+import sitemap from "@astrojs/sitemap";
 
 export default defineConfig({
   site: "https://leaderboard.querygym.com",
   output: "static",
-  integrations: [tailwind({ applyBaseStyles: false }), solid()],
+  integrations: [
+    tailwind({ applyBaseStyles: false }),
+    solid(),
+    sitemap({
+      changefreq: "weekly",
+      priority: 0.5,
+      lastmod: new Date(),
+      serialize(item) {
+        // Home page is the canonical entry point.
+        if (item.url === "https://leaderboard.querygym.com/") {
+          return { ...item, priority: 1.0, changefreq: "weekly" };
+        }
+        // Per-run detail pages are mostly internal-link targets — give them
+        // lower priority so search engines focus on the dataset/method/model
+        // index pages.
+        if (item.url.startsWith("https://leaderboard.querygym.com/runs/")) {
+          return { ...item, priority: 0.3, changefreq: "monthly" };
+        }
+        return item;
+      },
+    }),
+  ],
   vite: {
     ssr: {
       // Needed because we read CSV/YAML at build time from outside the project root.

--- a/reproducibility/site/package.json
+++ b/reproducibility/site/package.json
@@ -13,22 +13,23 @@
     "check": "astro check"
   },
   "dependencies": {
-    "@qg/shared": "workspace:*",
-    "astro": "^5.0.0",
-    "@astrojs/tailwind": "^5.1.5",
+    "@astrojs/sitemap": "^3.7.2",
     "@astrojs/solid-js": "^5.0.0",
-    "solid-js": "^1.9.0",
+    "@astrojs/tailwind": "^5.1.5",
+    "@qg/shared": "workspace:*",
     "@tanstack/solid-table": "^8.20.0",
-    "tailwindcss": "^3.4.0",
+    "astro": "^5.0.0",
+    "js-yaml": "^4.1.0",
     "papaparse": "^5.4.1",
-    "js-yaml": "^4.1.0"
+    "solid-js": "^1.9.0",
+    "tailwindcss": "^3.4.0"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^20.0.0",
+    "@types/papaparse": "^5.3.15",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0",
-    "wrangler": "^4.0.0",
-    "@types/papaparse": "^5.3.15",
-    "@types/js-yaml": "^4.0.9",
-    "@types/node": "^20.0.0"
+    "wrangler": "^4.0.0"
   }
 }

--- a/reproducibility/site/public/robots.txt
+++ b/reproducibility/site/public/robots.txt
@@ -1,0 +1,5 @@
+# leaderboard.querygym.com — open to all well-behaved crawlers.
+User-agent: *
+Allow: /
+
+Sitemap: https://leaderboard.querygym.com/sitemap-index.xml

--- a/reproducibility/site/src/components/EmptyState.astro
+++ b/reproducibility/site/src/components/EmptyState.astro
@@ -16,8 +16,6 @@ const {
   <a
     href="https://querygym.readthedocs.io/en/latest/user-guide/reproducibility/"
     class="mt-4 inline-block rounded-md bg-qg-accent px-4 py-2 text-sm font-medium text-white hover:opacity-90"
-    target="_blank"
-    rel="noopener noreferrer"
   >
     How to submit a result →
   </a>

--- a/reproducibility/site/src/layouts/Default.astro
+++ b/reproducibility/site/src/layouts/Default.astro
@@ -11,6 +11,7 @@ interface Props {
 
 const { title, description } = Astro.props;
 
+// External links render the linkout icon and open in the current tab.
 const navLinks = [
   { label: "Datasets", href: "/datasets/" },
   { label: "Methods", href: "/methods/" },

--- a/reproducibility/site/src/layouts/Default.astro
+++ b/reproducibility/site/src/layouts/Default.astro
@@ -29,6 +29,7 @@ const navLinks = [
     <title>{title} — QueryGym Leaderboard</title>
     {description && <meta name="description" content={description} />}
     <link rel="icon" type="image/png" href="/querygym-logo.png" />
+    <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap-index.xml" />
 
     <GoogleAnalytics />
   </head>

--- a/web/shared/components/Footer.astro
+++ b/web/shared/components/Footer.astro
@@ -35,7 +35,7 @@ const baseLinks: FooterLink[] = [
       {
         [...baseLinks, ...extraLinks].map((l) => (
           <li>
-            <a class="hover:text-qg-fg" href={l.href} target="_blank" rel="noopener noreferrer">
+            <a class="hover:text-qg-fg" href={l.href}>
               {l.label}
             </a>
           </li>

--- a/web/shared/components/Header.astro
+++ b/web/shared/components/Header.astro
@@ -7,7 +7,15 @@
 interface NavLink {
   label: string;
   href: string;
+  /**
+   * Renders the external-link arrow icon next to the label so users can see
+   * at a glance that the link leaves the current site. Note: by default the
+   * link still opens in the *same* tab — set `newTab: true` for cross-site
+   * links you really want to open in a fresh tab.
+   */
   external?: boolean;
+  /** Open in a new tab. Adds rel="noopener noreferrer" automatically. */
+  newTab?: boolean;
 }
 
 interface Props {
@@ -44,11 +52,28 @@ const {
         links.map((l) => (
           <a
             href={l.href}
-            class="rounded px-3 py-1.5 text-sm font-medium text-white/90 hover:bg-white/15 hover:text-white"
-            target={l.external ? "_blank" : undefined}
-            rel={l.external ? "noopener noreferrer" : undefined}
+            class="inline-flex items-center gap-1 rounded px-3 py-1.5 text-sm font-medium text-white/90 hover:bg-white/15 hover:text-white"
+            target={l.newTab ? "_blank" : undefined}
+            rel={l.newTab ? "noopener noreferrer" : undefined}
           >
             {l.label}
+            {l.external && (
+              <svg
+                aria-hidden="true"
+                width="11"
+                height="11"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class="opacity-80"
+              >
+                <path d="M7 17 17 7" />
+                <path d="M8 7h9v9" />
+              </svg>
+            )}
           </a>
         ))
       }

--- a/web/site/src/components/EcosystemMap.astro
+++ b/web/site/src/components/EcosystemMap.astro
@@ -53,8 +53,6 @@ const cards = [
       cards.map((c) => (
         <a
           href={c.href}
-          target={c.href.startsWith("http") ? "_blank" : undefined}
-          rel={c.href.startsWith("http") ? "noopener noreferrer" : undefined}
           class:list={[
             "qg-card flex flex-col justify-between !p-5",
             c.primary && "!border-qg-accent",

--- a/web/site/src/layouts/Default.astro
+++ b/web/site/src/layouts/Default.astro
@@ -33,13 +33,17 @@ const SITE = "https://querygym.com";
 const canonical = new URL(Astro.url.pathname, SITE).toString();
 const ogImageAbsolute = new URL(ogImage, SITE).toString();
 
+// External links use `external: true` (renders the linkout icon) and open in
+// the *current* tab — opening a new tab silently is a worse UX than letting
+// the user middle-click / cmd-click when they want a tab.
 const navLinks = [
   { label: "Install", href: "/install" },
   { label: "Methods", href: "/methods" },
   { label: "Reproducibility", href: "/reproducibility" },
   { label: "Cite", href: "/cite" },
   { label: "Docs", href: "https://querygym.readthedocs.io", external: true },
-  { label: "Dashboard ↗", href: "https://dashboard.querygym.com", external: true },
+  { label: "Leaderboard", href: "https://leaderboard.querygym.com", external: true },
+  { label: "Dashboard", href: "https://dashboard.querygym.com", external: true },
 ];
 
 const fullTitle = `${title} — QueryGym`;
@@ -78,7 +82,7 @@ const metaDescription =
     <meta name="twitter:image" content={ogImageAbsolute} />
 
     <link rel="icon" type="image/png" href="/querygym-logo.png" />
-    <link rel="sitemap" href="/sitemap-index.xml" />
+    <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap-index.xml" />
 
     {jsonLd && <script type="application/ld+json" set:html={jsonLd} />}
 


### PR DESCRIPTION
## What happened

PRs #14 (\`chore/nav-and-sitemap-stacked\`) and #15 (\`chore/leaderboard-sitemap\`) were stacked on each other and on PR #13 (\`chore/copy-polish\`). When #13 merged into main, GitHub didn't auto-retarget the stacked PRs — it merged each into its now-deleted base branch instead. They show "MERGED" in GitHub's UI but **none of their commits reached main**, so:

- Leaderboard isn't in the marketing nav.
- Marketing nav still says \`Dashboard ↗\` instead of \`Dashboard\` with linkout icon.
- \`leaderboard.querygym.com\` has no sitemap or robots.txt.

This is the same merge-into-base bug that hit PR #12 earlier in the rollout. **Lesson learned: stop stacking PRs in this repo. From here on, every PR bases off main.**

## Recovery

This PR cherry-picks the two orphaned commits onto a fresh branch off main:

- \`6cf0b25\` — Header linkout icons + current-tab (originally PR #14)
- \`cf35eb1\` — Leaderboard sitemap + robots.txt (originally PR #15)

## Verified locally

- \`pnpm -F @qg/site build\` → marketing nav reads \`Install / Methods / Reproducibility / Cite / Docs↗ / Leaderboard↗ / Dashboard↗\`. Leaderboard is before Dashboard (per user request). Both with linkout icons, both opening in the current tab.
- \`pnpm -F @qg/leaderboard build\` → 37 pages + \`sitemap-index.xml\` + \`sitemap-0.xml\` + \`robots.txt\` all in \`dist/\`.
- Header component supports separate \`external\` (icon) and \`newTab\` (target) props; default behavior is current-tab.

## After merge

1. CF Pages auto-redeploys both projects.
2. Verify on the live sites: \`https://querygym.com\` has Leaderboard + Dashboard in the nav; \`https://leaderboard.querygym.com/sitemap-index.xml\` resolves.
3. Submit \`https://leaderboard.querygym.com/sitemap-index.xml\` to Google Search Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)