### PR TITLE
Alias /sitemap.xml on both sites + recover orphaned newTab commit

### DIFF
--- a/reproducibility/site/public/_redirects
+++ b/reproducibility/site/public/_redirects
@@ -2,3 +2,7 @@
 # leaderboard.querygym.com.
 /leaderboard      /                      301
 /index.html       /                      301
+
+# Alias /sitemap.xml -> /sitemap-index.xml (200 = rewrite, not redirect).
+# GSC and other crawlers default to probing /sitemap.xml.
+/sitemap.xml      /sitemap-index.xml     200

--- a/reproducibility/site/src/layouts/Default.astro
+++ b/reproducibility/site/src/layouts/Default.astro
@@ -11,13 +11,14 @@ interface Props {
 
 const { title, description } = Astro.props;
 
-// External links render the linkout icon and open in the current tab.
+// Top-menu linkout items (external: true) open in a new tab so the user
+// keeps their place on the leaderboard when they cross to a sibling site.
 const navLinks = [
   { label: "Datasets", href: "/datasets/" },
   { label: "Methods", href: "/methods/" },
   { label: "Models", href: "/models/" },
   { label: "About", href: "/about" },
-  { label: "Toolkit", href: "https://querygym.com", external: true },
+  { label: "Toolkit", href: "https://querygym.com", external: true, newTab: true },
 ];
 ---
 

--- a/web/site/public/_redirects
+++ b/web/site/public/_redirects
@@ -6,3 +6,10 @@
 /leaderboard         https://leaderboard.querygym.com/   301
 /leaderboard.html    https://leaderboard.querygym.com/   301
 /QueryGym/*          https://querygym.com/:splat         301
+
+# Alias the canonical /sitemap.xml path to the @astrojs/sitemap-generated
+# index. Google Search Console's "Add a sitemap" form auto-suggests
+# /sitemap.xml; tools like Bing/Yandex/IndexNow probe it; humans type it.
+# The 200 status is a rewrite (URL stays the same in the browser), not a
+# redirect — keeps the canonical URL for crawlers stable.
+/sitemap.xml         /sitemap-index.xml                  200

--- a/web/site/src/layouts/Default.astro
+++ b/web/site/src/layouts/Default.astro
@@ -33,17 +33,18 @@ const SITE = "https://querygym.com";
 const canonical = new URL(Astro.url.pathname, SITE).toString();
 const ogImageAbsolute = new URL(ogImage, SITE).toString();
 
-// External links use `external: true` (renders the linkout icon) and open in
-// the *current* tab — opening a new tab silently is a worse UX than letting
-// the user middle-click / cmd-click when they want a tab.
+// Top-menu linkout items (external: true) open in a new tab so the user
+// keeps their place on querygym.com when they leave to a sibling site.
+// Everywhere else on the page (footer, hero CTAs, ecosystem cards, in-page
+// citations) stays same-tab unless explicitly noted.
 const navLinks = [
   { label: "Install", href: "/install" },
   { label: "Methods", href: "/methods" },
   { label: "Reproducibility", href: "/reproducibility" },
   { label: "Cite", href: "/cite" },
-  { label: "Docs", href: "https://querygym.readthedocs.io", external: true },
-  { label: "Leaderboard", href: "https://leaderboard.querygym.com", external: true },
-  { label: "Dashboard", href: "https://dashboard.querygym.com", external: true },
+  { label: "Docs", href: "https://querygym.readthedocs.io", external: true, newTab: true },
+  { label: "Leaderboard", href: "https://leaderboard.querygym.com", external: true, newTab: true },
+  { label: "Dashboard", href: "https://dashboard.querygym.com", external: true, newTab: true },
 ];
 
 const fullTitle = `${title} — QueryGym`;


### PR DESCRIPTION
## TL;DR

**Both sitemap-index URLs are healthy** (HTTP 200, valid XML, correct content-type, robots allows). I verified live with both regular curl and a Googlebot user-agent:

\`\`\`
$ curl -s https://querygym.com/sitemap-index.xml
<sitemapindex>...<loc>https://querygym.com/sitemap-0.xml</loc>...</sitemapindex>

$ curl -s https://leaderboard.querygym.com/sitemap-index.xml  
<sitemapindex>...<loc>https://leaderboard.querygym.com/sitemap-0.xml</loc>...</sitemapindex>
\`\`\`

The sitemap files aren't broken. **What was broken: \`/sitemap.xml\` (no \`-index\`) returned 404 on both sites** — and that's the URL Google Search Console's "Add a sitemap" form auto-suggests when you start typing. If you submitted \`sitemap.xml\` to GSC, you'd get "Couldn't fetch" because that path 404'd.

## Fix

Adds a rewrite to each project's \`public/_redirects\`:

\`\`\`
/sitemap.xml  /sitemap-index.xml  200
\`\`\`

Status \`200\` is a **rewrite** (URL stays the same in the browser), not a redirect — \`/sitemap.xml\` now serves the index content directly. Both URLs work; either is valid to submit.

## Also includes a recovery commit

PR #16 was merged before my final commit \`9ba7648\` ("Top-menu linkouts use new tab") landed in it. Cherry-picked here so:
- Marketing top nav: Docs/Leaderboard/Dashboard linkouts → new tab
- Leaderboard top nav: Toolkit linkout → new tab
- Footer + in-page links: same tab

## After merge

1. CF Pages auto-redeploys both sites.
2. \`https://querygym.com/sitemap.xml\` and \`https://leaderboard.querygym.com/sitemap.xml\` will return 200 with the sitemap-index content.
3. **Retry GSC submission** with either form:
   - \`https://querygym.com/sitemap.xml\`
   - \`https://querygym.com/sitemap-index.xml\`
4. Note: GSC "Couldn't fetch" is also frequently transient for 24–48h while Google gets around to crawling. If \`curl -I\` returns 200, the submission is healthy.

## GSC checklist (independent of this PR)

If submission still fails after the fix is deployed:

| Check | Command / where |
|---|---|
| URL returns 200 | \`curl -I https://querygym.com/sitemap.xml\` |
| Content-Type is XML | \`curl -I\` shows \`content-type: application/xml\` |
| Property scope covers the host | GSC → property settings → verified domain matches |
| Domain property recommended | GSC supports one Domain property covering both \`querygym.com\` AND \`leaderboard.querygym.com\` |
| Wait 24–48h | "Couldn't fetch" is often pending, not failed |

## Test plan

- [x] \`pnpm -F @qg/site build\` includes the rewrite in \`dist/_redirects\`.
- [x] \`pnpm -F @qg/leaderboard build\` includes the rewrite.
- [ ] After CF deploy: \`curl -I https://querygym.com/sitemap.xml\` returns 200.
- [ ] Same for leaderboard.
- [ ] GSC re-submission succeeds (or shows "Pending" briefly before success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)