### PR TITLE
Bump wrangler compatibility_date to 2026-04-15

### DIFF
--- a/reproducibility/site/wrangler.jsonc
+++ b/reproducibility/site/wrangler.jsonc
@@ -8,13 +8,15 @@
  * protocol used by the @qg/shared dep. Pre-providing this config + the
  * wrangler devDep skips the auto-config and deploys dist/ as static assets.
  *
- * compatibility_date is intentionally kept old-ish (well-tested) — bump only
- * when adopting a new Workers runtime feature.
+ * compatibility_date pins the Workers runtime behavior. Cloudflare ships
+ * fixes and feature changes under dated flags so old deployments keep
+ * working when the runtime evolves. Bump when picking up a new feature or
+ * roughly twice a year as housekeeping.
  */
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "querygym-leaderboard",
-  "compatibility_date": "2025-09-01",
+  "compatibility_date": "2026-04-15",
   "assets": {
     "directory": "./dist"
   }

--- a/web/site/wrangler.jsonc
+++ b/web/site/wrangler.jsonc
@@ -8,7 +8,7 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "querygym-site",
-  "compatibility_date": "2025-09-01",
+  "compatibility_date": "2026-04-15",
   "assets": {
     "directory": "./dist"
   }


### PR DESCRIPTION
## Summary

Both Pages projects (\`querygym-site\`, \`querygym-leaderboard\`) had \`compatibility_date: "2025-09-01"\` in their \`wrangler.jsonc\`. Bumping to \`2026-04-15\` for housekeeping — picks up several months of Workers runtime fixes and default-flag changes.

\`compatibility_date\` is the Workers runtime version pin. Cloudflare ships behavior changes under dated flags so old deployments don't break when the runtime evolves. The "Workers + Static Assets" mode we use isn't sensitive to most of the dated flags; this is mostly hygiene.

Also updated the comment in \`reproducibility/site/wrangler.jsonc\` to clarify the bump cadence ("roughly twice a year, or when picking up a new feature") instead of the old "intentionally old-ish."

## Test plan

- [x] \`pnpm -F @qg/site build\` succeeds.
- [x] \`pnpm -F @qg/leaderboard build\` succeeds.
- [ ] CF Pages re-deploys both projects; both serve as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)