### PR TITLE
Schema: optional artifacts + DL-HARD dataset entry

### DIFF
--- a/dataset_registry.yaml
+++ b/dataset_registry.yaml
@@ -53,6 +53,21 @@ datasets:
       runfile_template: "run.msmarco-v1-passage.bm25-default.dl20.txt"
       eval_metrics: ["map", "ndcg_cut.10", "recall.1000"]
 
+  msmarco-v1-passage.dlhard:
+    name: "DL-HARD — MS MARCO v1 Passage (hard subset)"
+    index:
+      name: "msmarco-v1-passage"
+    topics:
+      name: "dl-hard"
+    qrels:
+      name: "dl-hard"
+    bm25_weights:
+      k1: 0.9
+      b: 0.4
+    output:
+      runfile_template: "run.msmarco-v1-passage.bm25-default.dlhard.txt"
+      eval_metrics: ["ndcg_cut.10", "recall.1000"]
+
 ################### BEIR Datasets ########################
 
   beir-v1.0.0-trec-covid:

--- a/reproducibility/lib/emit.py
+++ b/reproducibility/lib/emit.py
@@ -77,6 +77,28 @@ def _detect_environment() -> dict:
     return env
 
 
+_ARTIFACT_KEYS = ("run_file", "reformulated_queries")
+_ARTIFACT_SUFFIX = {"run_file": "run.txt", "reformulated_queries": "queries.tsv"}
+
+
+def _build_artifacts(params_hash: str, present: set[str] | None) -> dict:
+    """Build the artifacts dict.
+
+    `present` selects which artifact filenames to include. None → both (the
+    default for the standard pipeline). Empty set → no artifacts (when neither
+    the ranking nor the reformulated-queries file is attached to the run).
+    Unknown keys raise.
+    """
+    if present is None:
+        keys = _ARTIFACT_KEYS
+    else:
+        unknown = set(present) - set(_ARTIFACT_KEYS)
+        if unknown:
+            raise ValueError(f"unknown artifact keys: {sorted(unknown)}")
+        keys = tuple(k for k in _ARTIFACT_KEYS if k in present)
+    return {k: f"{params_hash}.{_ARTIFACT_SUFFIX[k]}" for k in keys}
+
+
 def _querygym_version() -> str:
     """Read querygym.__version__ if available, else 'unknown'."""
     try:
@@ -102,6 +124,7 @@ def build_run_summary(
     submitted_at: str | None = None,
     environment: Mapping[str, Any] | None = None,
     querygym_version: str | None = None,
+    artifacts_present: set[str] | None = None,
 ) -> dict:
     """Assemble a schema-v1 run summary dict.
 
@@ -157,10 +180,7 @@ def build_run_summary(
         },
         "metrics": {k: float(v) for k, v in metrics.items()},
         "timing": {k: float(v) for k, v in timing.items()},
-        "artifacts": {
-            "run_file": f"{params_hash}.run.txt",
-            "reformulated_queries": f"{params_hash}.queries.tsv",
-        },
+        "artifacts": _build_artifacts(params_hash, artifacts_present),
     }
 
     payload["run_id"] = compute_run_id(payload)

--- a/reproducibility/schema.json
+++ b/reproducibility/schema.json
@@ -168,17 +168,16 @@
     "artifacts": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["run_file", "reformulated_queries"],
       "properties": {
         "run_file": {
           "type": "string",
           "pattern": "^[0-9a-f]{8}\\.run\\.txt$",
-          "description": "Sibling TREC run file. Filename must equal {params_hash}.run.txt."
+          "description": "Optional. Sibling TREC run file. Filename must equal {params_hash}.run.txt. Emitted by the standard pipeline; may be omitted when no ranking artifact is attached to the run."
         },
         "reformulated_queries": {
           "type": "string",
           "pattern": "^[0-9a-f]{8}\\.queries\\.tsv$",
-          "description": "Sibling reformulated queries TSV. Filename must equal {params_hash}.queries.tsv."
+          "description": "Optional. Sibling reformulated-queries TSV. Filename must equal {params_hash}.queries.tsv. Same optional semantics as run_file."
         }
       }
     }

--- a/reproducibility/scripts/submit_run.py
+++ b/reproducibility/scripts/submit_run.py
@@ -43,25 +43,20 @@ def _find(from_dir: Path, candidates: tuple[str, ...]) -> Path | None:
     return None
 
 
-def _resolve_inputs(from_dir: Path) -> tuple[Path, Path, Path]:
+def _resolve_inputs(from_dir: Path) -> tuple[Path, Path | None, Path | None]:
+    """Locate pipeline_summary.json (required) and the two optional artifacts.
+
+    `run.txt` and `reformulated_queries.tsv` are optional. Whether they must
+    be present is driven by what the payload's `artifacts` block references —
+    see `main`.
+    """
     summary = _find(from_dir, SUMMARY_CANDIDATES)
     if summary is None:
         raise SystemExit(
             f"could not find pipeline_summary.json under {from_dir}. "
             f"Did the pipeline complete?"
         )
-    run_file = _find(from_dir, RUN_FILE_CANDIDATES)
-    if run_file is None:
-        raise SystemExit(
-            f"could not find run.txt under {from_dir} (looked in: {RUN_FILE_CANDIDATES})"
-        )
-    queries = _find(from_dir, QUERIES_CANDIDATES)
-    if queries is None:
-        raise SystemExit(
-            f"could not find reformulated_queries.tsv under {from_dir} "
-            f"(looked in: {QUERIES_CANDIDATES})"
-        )
-    return summary, run_file, queries
+    return summary, _find(from_dir, RUN_FILE_CANDIDATES), _find(from_dir, QUERIES_CANDIDATES)
 
 
 def _canonical_dir(runs_dir: Path, payload: dict) -> Path:
@@ -125,10 +120,9 @@ def main() -> int:
 
     target_dir = _canonical_dir(args.runs_dir, payload)
     h = payload["params_hash"]
+    artifacts = payload.get("artifacts", {})
 
     json_dst = target_dir / f"{h}.json"
-    run_dst = target_dir / f"{h}.run.txt"
-    queries_dst = target_dir / f"{h}.queries.tsv"
 
     target_dir.mkdir(parents=True, exist_ok=True)
 
@@ -142,8 +136,23 @@ def main() -> int:
         json.dump(payload, f, indent=2, sort_keys=False)
         f.write("\n")
 
-    _copy(run_file, run_dst, force=args.force)
-    _copy(queries, queries_dst, force=args.force)
+    # Copy each artifact the payload references; require the source file to
+    # exist iff referenced. Artifacts the payload omits are simply not copied.
+    if "run_file" in artifacts:
+        if run_file is None:
+            raise SystemExit(
+                f"payload references artifacts.run_file but no run.txt found "
+                f"under {args.from_dir} (looked in: {RUN_FILE_CANDIDATES})"
+            )
+        _copy(run_file, target_dir / f"{h}.run.txt", force=args.force)
+    if "reformulated_queries" in artifacts:
+        if queries is None:
+            raise SystemExit(
+                f"payload references artifacts.reformulated_queries but no "
+                f"reformulated_queries.tsv found under {args.from_dir} "
+                f"(looked in: {QUERIES_CANDIDATES})"
+            )
+        _copy(queries, target_dir / f"{h}.queries.tsv", force=args.force)
 
     rel = json_dst.relative_to(_REPO_ROOT).as_posix()
     print(f"wrote {rel}")

--- a/reproducibility/tests/test_repro_schema.py
+++ b/reproducibility/tests/test_repro_schema.py
@@ -578,3 +578,26 @@ def test_build_run_summary_rejects_unknown_artifact_key():
     kw["artifacts_present"] = {"run_file", "bogus"}
     with pytest.raises(ValueError, match="unknown artifact keys"):
         build_run_summary(**kw)
+
+
+# ---------- DL-HARD registry entry ------------------------------------------
+
+
+def test_dataset_registry_has_dlhard_entry():
+    import yaml
+
+    p = Path(__file__).resolve().parents[2] / "dataset_registry.yaml"
+    reg = yaml.safe_load(p.read_text(encoding="utf-8"))["datasets"]
+    assert "msmarco-v1-passage.dlhard" in reg
+    entry = reg["msmarco-v1-passage.dlhard"]
+    assert entry["index"]["name"] == "msmarco-v1-passage"
+    assert set(entry["output"]["eval_metrics"]) >= {"ndcg_cut.10", "recall.1000"}
+
+
+def test_validator_accepts_dlhard_run():
+    kw = _build_kwargs()
+    kw["dataset_id"] = "msmarco-v1-passage.dlhard"
+    # DL-HARD whitelists {ndcg_cut.10, recall.1000}.
+    kw["metrics"] = {"ndcg_cut_10": 0.4038, "recall_1000": 0.8415}
+    p = build_run_summary(**kw)
+    validate(p)

--- a/reproducibility/tests/test_repro_schema.py
+++ b/reproducibility/tests/test_repro_schema.py
@@ -533,3 +533,48 @@ def test_run_summary_emits_lexical_retrieval_block():
     assert r["implementation"] == "pyserini:LuceneSearcher"
     assert "searcher" not in payload["config"]
     assert "bm25_weights" not in payload["config"]["dataset_config"]
+
+
+# ---------- Optional artifacts ----------------------------------------------
+
+
+def test_schema_accepts_empty_artifacts():
+    p = _minimal_payload_for_schema_only()
+    p["artifacts"] = {}
+    _raw_schema_validate(p)
+
+
+def test_schema_accepts_artifacts_with_only_run_file():
+    p = _minimal_payload_for_schema_only()
+    p["artifacts"] = {"run_file": "00000000.run.txt"}
+    _raw_schema_validate(p)
+
+
+def test_build_run_summary_artifacts_present_none_defaults_to_both():
+    p = build_run_summary(**_build_kwargs())
+    assert set(p["artifacts"]) == {"run_file", "reformulated_queries"}
+
+
+def test_build_run_summary_artifacts_present_empty_emits_no_artifacts():
+    kw = _build_kwargs()
+    kw["artifacts_present"] = set()
+    p = build_run_summary(**kw)
+    assert p["artifacts"] == {}
+    # validate (schema + registry + hash) passes
+    validate(p)
+
+
+def test_build_run_summary_artifacts_present_only_run_file():
+    kw = _build_kwargs()
+    kw["artifacts_present"] = {"run_file"}
+    p = build_run_summary(**kw)
+    assert set(p["artifacts"]) == {"run_file"}
+    assert p["artifacts"]["run_file"] == f"{p['params_hash']}.run.txt"
+    validate(p)
+
+
+def test_build_run_summary_rejects_unknown_artifact_key():
+    kw = _build_kwargs()
+    kw["artifacts_present"] = {"run_file", "bogus"}
+    with pytest.raises(ValueError, match="unknown artifact keys"):
+        build_run_summary(**kw)


### PR DESCRIPTION
## Summary

Two small additions:

**Optional artifacts in schema v1.** `artifacts.run_file` and `artifacts.reformulated_queries` become optional. Their filename regex patterns still apply when the fields are present, so a run remains valid whether it carries both, one, or neither artifact. This lets a run be published from just its scores when the per-run TREC ranking or queries TSV isn't attached.

- `reproducibility/schema.json` — `artifacts.required` removed.
- `reproducibility/lib/emit.py` — `build_run_summary` takes a new `artifacts_present` parameter to control which artifact fields are emitted (defaults to both, unchanged for the standard pipeline).
- `reproducibility/scripts/submit_run.py` — artifact files are required only when referenced by the payload, and silently skipped when omitted.

**`msmarco-v1-passage.dlhard` dataset entry.** Hard subset of MS MARCO passage queries. Uses the prebuilt `msmarco-v1-passage` index with default BM25 weights (k1=0.9, b=0.4); eval metrics `ndcg_cut.10`, `recall.1000`.

## Test Plan

- [x] `make repro-test` — 44 passed (36 prior + 8 new covering the optional artifact paths and the DL-HARD entry).
- [x] `make repro-check` — clean.
- [x] CI `reproducibility-check.yml` green on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)