### PR TITLE
site: drop "(locked)" qualifier from schema version label

### DIFF
--- a/web/site/src/pages/reproducibility.astro
+++ b/web/site/src/pages/reproducibility.astro
@@ -36,7 +36,7 @@ import CodeBlock from "../components/CodeBlock.astro";
       >
         <div>
           <div class="text-xs uppercase tracking-wide text-qg-fg-muted">schema</div>
-          <div class="mt-1 text-xl font-semibold">v1 (locked)</div>
+          <div class="mt-1 text-xl font-semibold">v1</div>
           <p class="mt-2 text-sm text-qg-fg-muted">
             Field-by-field documentation, validation rules, and a worked
             example. Mirrors the canonical JSON Schema file.


### PR DESCRIPTION
## Summary

The reproducibility schema card on querygym.com/reproducibility/ showed `v1 (locked)`. The schema is versioned but intentionally permissive (artifact fields are optional, multi-retriever support landed in PR #19), so the "locked" qualifier overstated the constraint. Renamed to just `v1`.

## Test Plan
- [x] One-line copy change; site builds cleanly.
- [x] Cloudflare Pages auto-deploys on merge to main; check that the card now reads `v1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)