### PR TITLE
site: remove dashboard links from marketing site and shared footer

### DIFF
--- a/web/shared/components/Footer.astro
+++ b/web/shared/components/Footer.astro
@@ -1,7 +1,7 @@
 ---
 /**
- * Shared footer. Three links: GitHub, papers, dashboard. Used across the
- * leaderboard and (in PR2) the marketing site.
+ * Shared footer. GitHub, docs, and paper links. Used across the
+ * leaderboard and the marketing site.
  */
 interface FooterLink {
   label: string;
@@ -21,7 +21,6 @@ const year = new Date().getFullYear();
 const baseLinks: FooterLink[] = [
   { label: "GitHub", href: "https://github.com/ls3-lab/QueryGym" },
   { label: "Docs", href: "https://querygym.readthedocs.io" },
-  { label: "Dashboard", href: "https://dashboard.querygym.com" },
   { label: "Paper", href: "https://arxiv.org/abs/2511.15996" },
 ];
 ---

--- a/web/site/src/components/EcosystemMap.astro
+++ b/web/site/src/components/EcosystemMap.astro
@@ -1,6 +1,6 @@
 ---
 /**
- * Visual map of the QueryGym ecosystem: Library / Dashboard / Leaderboard / Docs.
+ * Visual map of the QueryGym ecosystem: Library / Leaderboard / Docs.
  * Static SVG-free version using CSS grid + gradient borders.
  */
 
@@ -11,14 +11,6 @@ const cards = [
     body: "The toolkit itself. Methods, prompt bank, searchers, CLI.",
     href: "https://pypi.org/project/querygym/",
     cta: "pip install querygym",
-    primary: false,
-  },
-  {
-    label: "Dashboard",
-    sub: "dashboard.querygym.com",
-    body: "Hosted product. Run methods through a UI, compare results live, share runs. API keys + billing.",
-    href: "https://dashboard.querygym.com",
-    cta: "Open Dashboard ↗",
     primary: true,
   },
   {
@@ -43,12 +35,12 @@ const cards = [
 <section class="qg-section">
   <h2 class="text-3xl font-bold md:text-4xl">The ecosystem</h2>
   <p class="mt-3 max-w-2xl text-qg-fg-muted">
-    QueryGym is split into four surfaces. They share the same data contract,
-    so a run from the dashboard or a third-party submitter lands in the same
-    leaderboard as the toolkit's own results.
+    QueryGym is split into three surfaces. They share the same data contract,
+    so a run from the toolkit or a third-party submitter lands in the same
+    leaderboard.
   </p>
 
-  <div class="mt-10 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+  <div class="mt-10 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
     {
       cards.map((c) => (
         <a

--- a/web/site/src/components/FeatureGrid.astro
+++ b/web/site/src/components/FeatureGrid.astro
@@ -15,7 +15,7 @@ const features = [
   {
     title: "Stable run schema",
     body:
-      "Every run emits a versioned JSON conforming to a public JSON Schema — same shape across the toolkit, dashboard, and third-party submitters.",
+      "Every run emits a versioned JSON conforming to a public JSON Schema — same shape across the toolkit and third-party submitters.",
     icon: "🧬",
   },
   {
@@ -43,8 +43,8 @@ const features = [
   <h2 class="text-3xl font-bold md:text-4xl">What you get</h2>
   <p class="mt-3 max-w-2xl text-qg-fg-muted">
     QueryGym pairs a small, opinionated library with a contract-driven
-    reproducibility pipeline. The toolkit, the dashboard, and the leaderboard
-    all share the same data shape.
+    reproducibility pipeline. The toolkit and the leaderboard share the same
+    data shape.
   </p>
   <ul class="mt-10 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
     {

--- a/web/site/src/components/Hero.astro
+++ b/web/site/src/components/Hero.astro
@@ -1,8 +1,8 @@
 ---
 /**
  * Marketing hero: gradient panel + typed-query → expanded-query animation.
- * Two CTAs side-by-side: primary "Open Dashboard" (the hosted product),
- * secondary "Get Started" (pip install + docs).
+ * Two CTAs: primary "Get Started" (pip install + docs), secondary
+ * "View Leaderboard" (reproducibility results).
  */
 ---
 
@@ -19,23 +19,17 @@
       </p>
       <div class="mt-7 flex flex-wrap gap-3">
         <a
-          href="https://dashboard.querygym.com"
-          class="inline-flex items-center gap-2 rounded-md bg-white px-5 py-3 text-sm font-semibold text-qg-grad-end shadow-lg transition hover:bg-white/90"
-        >
-          Open Dashboard
-          <span aria-hidden="true">↗</span>
-        </a>
-        <a
           href="/install"
-          class="inline-flex items-center gap-2 rounded-md border border-white/30 bg-white/10 px-5 py-3 text-sm font-semibold text-white backdrop-blur transition hover:bg-white/20"
+          class="inline-flex items-center gap-2 rounded-md bg-white px-5 py-3 text-sm font-semibold text-qg-grad-end shadow-lg transition hover:bg-white/90"
         >
           Get Started
         </a>
         <a
           href="https://leaderboard.querygym.com"
-          class="inline-flex items-center gap-2 rounded-md px-5 py-3 text-sm font-semibold text-white/90 underline-offset-4 hover:underline"
+          class="inline-flex items-center gap-2 rounded-md border border-white/30 bg-white/10 px-5 py-3 text-sm font-semibold text-white backdrop-blur transition hover:bg-white/20"
         >
-          View Leaderboard →
+          View Leaderboard
+          <span aria-hidden="true">↗</span>
         </a>
       </div>
     </div>

--- a/web/site/src/layouts/Default.astro
+++ b/web/site/src/layouts/Default.astro
@@ -44,7 +44,6 @@ const navLinks = [
   { label: "Cite", href: "/cite" },
   { label: "Docs", href: "https://querygym.readthedocs.io", external: true, newTab: true },
   { label: "Leaderboard", href: "https://leaderboard.querygym.com", external: true, newTab: true },
-  { label: "Dashboard", href: "https://dashboard.querygym.com", external: true, newTab: true },
 ];
 
 const fullTitle = `${title} — QueryGym`;

--- a/web/site/src/pages/index.astro
+++ b/web/site/src/pages/index.astro
@@ -8,7 +8,7 @@ import MethodGrid from "../components/MethodGrid.astro";
 
 // JSON-LD: SoftwareApplication describing the QueryGym toolkit, plus a
 // nested Organization for the lab. Helps Google build a richer knowledge
-// panel and link the surfaces (site, dashboard, repo, leaderboard).
+// panel and link the surfaces (site, repo, leaderboard).
 const jsonLd = JSON.stringify({
   "@context": "https://schema.org",
   "@graph": [
@@ -100,25 +100,4 @@ print(result.reformulated)`}</CodeBlock>
     </div>
   </section>
 
-  <section class="qg-gradient text-white">
-    <div class="qg-section flex flex-col items-start justify-between gap-6 !py-14 md:flex-row md:items-center">
-      <div>
-        <h2 class="text-2xl font-bold md:text-3xl">
-          Run reformulations without writing a single line of code.
-        </h2>
-        <p class="mt-2 max-w-2xl text-white/85">
-          The QueryGym Dashboard is the hosted product layer — login, run
-          methods through a UI, compare results live, manage API keys, and
-          publish to the leaderboard.
-        </p>
-      </div>
-      <a
-        href="https://dashboard.querygym.com"
-        class="inline-flex items-center gap-2 whitespace-nowrap rounded-md bg-white px-5 py-3 text-sm font-semibold text-qg-grad-end shadow-lg transition hover:bg-white/90"
-      >
-        Open Dashboard
-        <span aria-hidden="true">↗</span>
-      </a>
-    </div>
-  </section>
 </Default>


### PR DESCRIPTION
## Summary

Removes every link to `dashboard.querygym.com` from both the marketing site (querygym.com) and the leaderboard site (via the shared footer).

**Touched files:**

- `web/shared/components/Footer.astro` — drop the Dashboard footer entry (affects both sites).
- `web/site/src/layouts/Default.astro` — drop the Dashboard top-menu nav link.
- `web/site/src/components/Hero.astro` — drop the "Open Dashboard" hero CTA; promote "Get Started" to primary, "View Leaderboard" to secondary.
- `web/site/src/components/EcosystemMap.astro` — drop the Dashboard card; ecosystem is now three surfaces (Library, Leaderboard, Docs); grid rebalanced to `lg:grid-cols-3`.
- `web/site/src/components/FeatureGrid.astro` — drop dashboard mentions from prose.
- `web/site/src/pages/index.astro` — drop the dedicated Dashboard CTA section; update JSON-LD comment.

After this PR, `grep -r dashboard web/ reproducibility/site/src` returns nothing.

## Test Plan
- [x] No remaining `dashboard` strings in web/ or reproducibility/site/src.
- [x] CF Pages auto-deploys both sites on merge; verify dashboard CTAs and footer link are gone on querygym.com and leaderboard.querygym.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)