### PR TITLE
leaderboard: BEIR-style matrix UI + per-LLM/method/retriever views + reproduce snippet

### DIFF
--- a/reproducibility/site/scripts/build-data.ts
+++ b/reproducibility/site/scripts/build-data.ts
@@ -1,25 +1,29 @@
 /**
- * build-data.ts — turn reproducibility/data + dataset_registry.yaml + method
- * registry into per-view JSON shards consumed by Astro pages.
+ * build-data.ts — turn reproducibility/data + dataset_registry.yaml +
+ * retriever_registry.yaml into per-view JSON shards consumed by Astro pages.
  *
  * Inputs:
  *   - ../data/results.csv            (canonical aggregate; one row per (run, metric))
  *   - ../data/manifest.json          (run/row counts + content hash)
  *   - ../data/runs/.../*.json         (per-run detail used by /runs/[run_id])
- *   - ../../dataset_registry.yaml    (full dataset list, even when csv is empty)
+ *   - ../../dataset_registry.yaml    (full dataset list)
+ *   - ../../reproducibility/retriever_registry.yaml  (retriever slug → display + paradigm)
  *
  * Outputs (gitignored, written to src/data/):
  *   - overview.json    summary used on /
- *   - datasets.json    [{id, name, run_count}]
+ *   - datasets.json    [{id, name, run_count, eval_metrics}]
  *   - methods.json     [{id, run_count}]
  *   - models.json      [{id, run_count}]
+ *   - retrievers.json  [{id, display_name, paradigm, run_count}]
+ *   - matrix.json      flat matrix: rows = (method, model, retriever), values per dataset
  *   - runs.json        full run index, keyed by run_id
- *   - views/dataset-{id}.json
- *   - views/method-{id}.json
- *   - views/model-{id}.json
+ *   - views/dataset-{id}.json   (per-dataset table — used by /datasets/{id})
+ *   - views/method-{id}.json    (per-method matrix — used by /methods/{id})
+ *   - views/model-{id}.json     (per-model matrix — used by /models/{id})
+ *   - views/retriever-{id}.json (per-retriever matrix — used by /retrievers/{id})
  *
- * Empty input is fine — empty shards still emit so pages render the empty
- * state. Run as: pnpm -F @qg/leaderboard build:data
+ * Empty input is fine — empty shards still emit so pages render the empty state.
+ * Run as: pnpm -F @qg/leaderboard build:data
  */
 
 import fs from "node:fs";
@@ -36,6 +40,11 @@ const RUNS_DIR = path.join(DATA_DIR, "runs");
 const RESULTS_CSV = path.join(DATA_DIR, "results.csv");
 const MANIFEST_JSON = path.join(DATA_DIR, "manifest.json");
 const REGISTRY_YAML = path.join(REPO_ROOT, "dataset_registry.yaml");
+const RETRIEVER_REGISTRY_YAML = path.join(
+  REPO_ROOT,
+  "reproducibility",
+  "retriever_registry.yaml",
+);
 
 const OUT_DIR = path.join(SITE_ROOT, "src", "data");
 const VIEWS_DIR = path.join(OUT_DIR, "views");
@@ -49,6 +58,8 @@ interface ResultRow {
   dataset_id: string;
   method_id: string;
   model: string;
+  retriever_id: string;
+  retriever: string; // display name from registry
   params_hash: string;
   method_params_json: string;
   llm_temperature: number;
@@ -71,12 +82,22 @@ interface DatasetEntry {
   run_count: number;
 }
 
+interface RetrieverEntry {
+  id: string;
+  display_name: string;
+  paradigm: string;
+  run_count: number;
+}
+
 interface RunDetail {
   run_id: string;
   params_hash: string;
   dataset_id: string;
   method_id: string;
   model: string;
+  retriever_id: string;
+  retriever_display: string;
+  paradigm: string;
   metrics: Record<string, number>;
   config: Record<string, unknown>;
   timing: Record<string, number>;
@@ -84,10 +105,11 @@ interface RunDetail {
   num_queries: number;
   querygym_version: string;
   submitted_at: string;
+  // Artifacts present in the payload (may be empty for legacy rows).
   artifacts: {
     json_url: string;
-    run_file_url: string;
-    queries_url: string;
+    run_file_url: string | null;
+    queries_url: string | null;
   };
 }
 
@@ -141,6 +163,14 @@ function readDatasetRegistry(): Record<string, Omit<DatasetEntry, "run_count">> 
   return out;
 }
 
+function readRetrieverRegistry(): Record<string, { display_name: string; paradigm: string }> {
+  if (!fs.existsSync(RETRIEVER_REGISTRY_YAML)) return {};
+  const doc = yaml.load(fs.readFileSync(RETRIEVER_REGISTRY_YAML, "utf-8")) as {
+    retrievers?: Record<string, { display_name: string; paradigm: string }>;
+  };
+  return doc.retrievers ?? {};
+}
+
 function* iterRunFiles(): Generator<string> {
   if (!fs.existsSync(RUNS_DIR)) return;
   const stack = [RUNS_DIR];
@@ -154,19 +184,25 @@ function* iterRunFiles(): Generator<string> {
   }
 }
 
-function readRunDetails(): Record<string, RunDetail> {
+function readRunDetails(retrievers: Record<string, { display_name: string; paradigm: string }>): Record<string, RunDetail> {
   const out: Record<string, RunDetail> = {};
   for (const filePath of iterRunFiles()) {
     const payload = JSON.parse(fs.readFileSync(filePath, "utf-8"));
     const rel = path.relative(REPO_ROOT, filePath).split(path.sep).join("/");
     const dirOnGitHub = path.dirname(rel);
     const hash = payload.params_hash;
+    const retr = payload.config?.retrieval ?? {};
+    const retrId = retr.retriever_id ?? "";
+    const artifacts = payload.artifacts ?? {};
     out[payload.run_id] = {
       run_id: payload.run_id,
       params_hash: hash,
       dataset_id: payload.pipeline.dataset_id,
       method_id: payload.pipeline.method_id,
       model: payload.pipeline.model,
+      retriever_id: retrId,
+      retriever_display: retrievers[retrId]?.display_name ?? retrId,
+      paradigm: retrievers[retrId]?.paradigm ?? retr.paradigm ?? "",
       metrics: payload.metrics,
       config: payload.config,
       timing: payload.timing,
@@ -176,130 +212,288 @@ function readRunDetails(): Record<string, RunDetail> {
       submitted_at: payload.submitted_at,
       artifacts: {
         json_url: `${GH_BLOB}/${rel}`,
-        run_file_url: `${GH_RAW}/${dirOnGitHub}/${hash}.run.txt`,
-        queries_url: `${GH_RAW}/${dirOnGitHub}/${hash}.queries.tsv`,
+        run_file_url: artifacts.run_file ? `${GH_RAW}/${dirOnGitHub}/${artifacts.run_file}` : null,
+        queries_url: artifacts.reformulated_queries ? `${GH_RAW}/${dirOnGitHub}/${artifacts.reformulated_queries}` : null,
       },
     };
   }
   return out;
 }
 
-function buildViews(
+// ---------- view builders ---------------------------------------------------
+
+function buildPerDatasetViews(
   rows: ResultRow[],
   datasets: Record<string, Omit<DatasetEntry, "run_count">>,
 ) {
-  // Index rows by composite keys so we can pivot per view.
   const byDataset = new Map<string, ResultRow[]>();
-  const byMethod = new Map<string, ResultRow[]>();
-  const byModel = new Map<string, ResultRow[]>();
-
   for (const r of rows) {
     if (!byDataset.has(r.dataset_id)) byDataset.set(r.dataset_id, []);
     byDataset.get(r.dataset_id)!.push(r);
-    if (!byMethod.has(r.method_id)) byMethod.set(r.method_id, []);
-    byMethod.get(r.method_id)!.push(r);
-    if (!byModel.has(r.model)) byModel.set(r.model, []);
-    byModel.get(r.model)!.push(r);
   }
 
-  // Run counts (unique run_ids per facet).
-  const datasetCounts = new Map<string, number>();
-  const methodCounts = new Map<string, number>();
-  const modelCounts = new Map<string, number>();
-  const seen = new Set<string>();
-  for (const r of rows) {
-    const key = r.run_id;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    datasetCounts.set(r.dataset_id, (datasetCounts.get(r.dataset_id) ?? 0) + 1);
-    methodCounts.set(r.method_id, (methodCounts.get(r.method_id) ?? 0) + 1);
-    modelCounts.set(r.model, (modelCounts.get(r.model) ?? 0) + 1);
-  }
-
-  // Per-dataset views: pivot rows so each (method, model, params_hash) is a
-  // single object with metric columns, and stamp best_for_metric flags.
   for (const [datasetId, dsRows] of byDataset) {
     const allowed = datasets[datasetId]?.eval_metrics ?? [];
-    const bestPerMetric = new Map<string, { value: number; runId: string }>();
-    for (const r of dsRows) {
-      const cur = bestPerMetric.get(r.metric);
-      if (!cur || r.value > cur.value) {
-        bestPerMetric.set(r.metric, { value: r.value, runId: r.run_id });
-      }
-    }
 
-    // Group rows into runs.
-    const runs = new Map<string, any>();
+    // Pivot to one row per (logical_method, model, retriever). Variants are
+    // folded by max value per metric — matches the home matrix.
+    const map = new Map<string, any>();
     for (const r of dsRows) {
-      if (!runs.has(r.run_id)) {
-        runs.set(r.run_id, {
-          run_id: r.run_id,
-          method_id: r.method_id,
+      const lm = logicalMethod(r.method_id, r.method_params_json);
+      const key = `${lm.id}|${r.model}|${r.retriever_id}`;
+      if (!map.has(key)) {
+        map.set(key, {
+          method_id: lm.id,
+          method_display: lm.display,
           model: r.model,
-          params_hash: r.params_hash,
-          method_params_json: r.method_params_json,
-          llm_temperature: r.llm_temperature,
-          llm_max_tokens: r.llm_max_tokens,
-          num_queries: r.num_queries,
-          total_time_seconds: r.total_time_seconds,
-          querygym_version: r.querygym_version,
-          run_file_path: r.run_file_path,
+          retriever_id: r.retriever_id,
+          retriever_display: r.retriever,
+          run_id: r.run_id,            // populated/overwritten by the best cell
           metrics: {} as Record<string, number>,
           best_for: {} as Record<string, boolean>,
         });
       }
-      const run = runs.get(r.run_id);
-      run.metrics[r.metric] = r.value;
-      run.best_for[r.metric] = bestPerMetric.get(r.metric)?.runId === r.run_id;
+      const row = map.get(key);
+      if (row.metrics[r.metric] === undefined || r.value > row.metrics[r.metric]) {
+        row.metrics[r.metric] = r.value;
+        row.run_id = r.run_id;
+      }
+    }
+
+    // best_for flags relative to the rows above.
+    const list = Array.from(map.values());
+    for (const m of allowed) {
+      let best = -Infinity;
+      let bestRow: any = null;
+      for (const row of list) {
+        const v = row.metrics[m];
+        if (v !== undefined && v > best) { best = v; bestRow = row; }
+      }
+      if (bestRow) bestRow.best_for[m] = true;
     }
 
     writeJSON(path.join(VIEWS_DIR, `dataset-${datasetId}.json`), {
       dataset_id: datasetId,
       dataset: datasets[datasetId] ?? { id: datasetId, name: datasetId, eval_metrics: allowed },
       metric_columns: allowed,
-      runs: Array.from(runs.values()),
+      runs: list,
     });
   }
+}
 
-  // Method and model views: similar, but the "row" identity is dataset rather
-  // than method/model.
-  function writePivotView(
-    dir: string,
-    keyId: string,
-    sourceRows: ResultRow[],
-    rowKey: keyof ResultRow,
-  ) {
-    const items = new Map<string, any>();
-    for (const r of sourceRows) {
-      const id = String(r[rowKey]);
-      if (!items.has(id)) {
-        items.set(id, {
-          [rowKey]: id,
-          run_id: r.run_id,
-          dataset_id: r.dataset_id,
-          method_id: r.method_id,
-          model: r.model,
-          params_hash: r.params_hash,
-          metrics: {} as Record<string, number>,
-        });
-      }
-      items.get(id).metrics[r.metric] = r.value;
+/**
+ * Logical method = the leaderboard-display unit.
+ *
+ * - For `query2doc`, the three `mode` variants (zs/fs/cot) are surfaced as
+ *   separate logical methods (`query2doc-zs`, `query2doc-fs`, `query2doc-cot`),
+ *   matching how the SIGIR paper presents them.
+ * - For every other method_id, identity.
+ *
+ * This collapses accidental param noise in legacy runs (e.g. an extra
+ * `judge_rel_mode` field, machine-specific paths in `query2doc-fs`) into the
+ * same display row, while keeping genuinely different variants distinct.
+ */
+function logicalMethod(
+  method_id: string,
+  paramsJson: string,
+): { id: string; display: string } {
+  if (method_id === "query2doc") {
+    try {
+      const p = JSON.parse(paramsJson || "{}");
+      const mode = String(p.mode ?? "zs").toLowerCase();
+      return { id: `query2doc-${mode}`, display: `Q2D (${mode.toUpperCase()})` };
+    } catch {
+      return { id: method_id, display: method_id };
     }
-    writeJSON(path.join(VIEWS_DIR, `${dir}-${keyId}.json`), {
-      [`${dir}_id`]: keyId,
-      items: Array.from(items.values()),
-    });
+  }
+  return { id: method_id, display: method_id };
+}
+
+/**
+ * One matrix-style row keyed by an "axis" tuple (e.g. (logical_method, model,
+ * retriever) for the home page). Columns are dataset × metric. Each cell
+ * carries value + best flag + run_id.
+ *
+ * Within each axis-group, when multiple legacy variants exist for the same
+ * cell, the one with the highest metric value wins (display-side dedup).
+ */
+function buildMatrix(
+  rows: ResultRow[],
+  axisKey: (r: ResultRow, lm: { id: string; display: string }) => string,
+  axisExtract: (r: ResultRow, lm: { id: string; display: string }) => Record<string, string>,
+) {
+  const map = new Map<string, any>();
+
+  for (const r of rows) {
+    const lm = logicalMethod(r.method_id, r.method_params_json);
+    const key = axisKey(r, lm);
+    if (!map.has(key)) {
+      map.set(key, {
+        ...axisExtract(r, lm),
+        run_ids: {} as Record<string, string>,    // dataset_id → run_id of best cell
+        values: {} as Record<string, Record<string, { value: number; best: boolean }>>,
+      });
+    }
+    const row = map.get(key);
+    if (!row.values[r.dataset_id]) row.values[r.dataset_id] = {};
+    const cur = row.values[r.dataset_id][r.metric];
+    if (!cur || r.value > cur.value) {
+      row.values[r.dataset_id][r.metric] = { value: r.value, best: false };
+      // The "winning" run for this cell (used for the row → run_detail link).
+      // If different metrics inside the same cell come from different legacy
+      // variants, keep the most recent assignment (any is correct).
+      row.run_ids[r.dataset_id] = r.run_id;
+    }
   }
 
-  for (const [methodId, mRows] of byMethod) {
-    writePivotView("method", methodId, mRows, "run_id");
+  // "Best in column" across all axis rows.
+  const list = Array.from(map.values());
+  const bestPerCol = new Map<string, { value: number; rowIdx: number }>();
+  list.forEach((row, idx) => {
+    for (const [ds, metrics] of Object.entries(row.values)) {
+      for (const [m, cell] of Object.entries(metrics as Record<string, { value: number; best: boolean }>)) {
+        const colKey = `${ds}|${m}`;
+        const cur = bestPerCol.get(colKey);
+        if (!cur || cell.value > cur.value) bestPerCol.set(colKey, { value: cell.value, rowIdx: idx });
+      }
+    }
+  });
+  bestPerCol.forEach(({ rowIdx }, colKey) => {
+    const [ds, m] = colKey.split("|");
+    list[rowIdx].values[ds][m].best = true;
+  });
+  return list;
+}
+
+function buildHomeMatrix(
+  rows: ResultRow[],
+  datasets: Record<string, Omit<DatasetEntry, "run_count">>,
+) {
+  const matrixRows = buildMatrix(
+    rows,
+    (_r, lm) => `${lm.id}|${_r.model}|${_r.retriever_id}`,
+    (r, lm) => ({
+      method_id: lm.id,
+      method_display: lm.display,
+      model: r.model,
+      retriever_id: r.retriever_id,
+      retriever_display: r.retriever,
+    }),
+  );
+
+  // Dataset columns + primary/secondary metric per dataset.
+  // Primary = nDCG@10 if present, else first eval metric.
+  // Secondary = recall@1000 (DL) or recall@100 (BEIR), else null.
+  const datasetCols = Object.values(datasets)
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .map((d) => {
+      const metrics = d.eval_metrics;
+      const primary =
+        metrics.find((m) => m === "ndcg_cut_10") ??
+        metrics[0] ??
+        null;
+      const secondary =
+        metrics.find((m) => m === "recall_1000") ??
+        metrics.find((m) => m === "recall_100") ??
+        metrics.find((m) => m !== primary) ??
+        null;
+      return {
+        id: d.id,
+        name: d.name,
+        primary_metric: primary,
+        secondary_metric: secondary,
+        all_metrics: metrics,
+      };
+    });
+
+  return {
+    dataset_columns: datasetCols,
+    rows: matrixRows,
+  };
+}
+
+function buildPerModelViews(rows: ResultRow[]) {
+  const byModel = new Map<string, ResultRow[]>();
+  for (const r of rows) {
+    if (!byModel.has(r.model)) byModel.set(r.model, []);
+    byModel.get(r.model)!.push(r);
   }
   for (const [model, mRows] of byModel) {
-    writePivotView("model", model, mRows, "run_id");
+    const matrix = buildMatrix(
+      mRows,
+      (r, lm) => `${lm.id}|${r.retriever_id}`,
+      (r, lm) => ({
+        method_id: lm.id,
+        method_display: lm.display,
+        retriever_id: r.retriever_id,
+        retriever_display: r.retriever,
+      }),
+    );
+    writeJSON(path.join(VIEWS_DIR, `model-${encodePathSegment(model)}.json`), {
+      model,
+      rows: matrix,
+    });
   }
-
-  return { datasetCounts, methodCounts, modelCounts };
 }
+
+function buildPerMethodViews(rows: ResultRow[]) {
+  // Group by *logical* method (so q2d-zs / q2d-fs / q2d-cot each get their
+  // own /methods/{id} page, mirroring how the SIGIR paper presents them).
+  const byLogicalMethod = new Map<string, { display: string; rows: ResultRow[] }>();
+  for (const r of rows) {
+    const lm = logicalMethod(r.method_id, r.method_params_json);
+    if (!byLogicalMethod.has(lm.id)) {
+      byLogicalMethod.set(lm.id, { display: lm.display, rows: [] });
+    }
+    byLogicalMethod.get(lm.id)!.rows.push(r);
+  }
+  for (const [method_id, { display, rows: mRows }] of byLogicalMethod) {
+    const matrix = buildMatrix(
+      mRows,
+      (r) => `${r.model}|${r.retriever_id}`,
+      (r) => ({
+        model: r.model,
+        retriever_id: r.retriever_id,
+        retriever_display: r.retriever,
+      }),
+    );
+    writeJSON(path.join(VIEWS_DIR, `method-${method_id}.json`), {
+      method_id,
+      method_display: display,
+      rows: matrix,
+    });
+  }
+}
+
+function buildPerRetrieverViews(rows: ResultRow[]) {
+  const byRetriever = new Map<string, ResultRow[]>();
+  for (const r of rows) {
+    if (!byRetriever.has(r.retriever_id)) byRetriever.set(r.retriever_id, []);
+    byRetriever.get(r.retriever_id)!.push(r);
+  }
+  for (const [retriever_id, mRows] of byRetriever) {
+    const matrix = buildMatrix(
+      mRows,
+      (r, lm) => `${lm.id}|${r.model}`,
+      (r, lm) => ({
+        method_id: lm.id,
+        method_display: lm.display,
+        model: r.model,
+      }),
+    );
+    writeJSON(path.join(VIEWS_DIR, `retriever-${retriever_id}.json`), {
+      retriever_id,
+      rows: matrix,
+    });
+  }
+}
+
+// Some model ids contain "/" (e.g. "openai/gpt-4.1"); URL-encode for file paths.
+function encodePathSegment(s: string): string {
+  return s.replace(/\//g, "__");
+}
+
+// ---------- main ------------------------------------------------------------
 
 function main() {
   ensureDir(OUT_DIR);
@@ -308,9 +502,35 @@ function main() {
   const rows = readCSV();
   const manifest = readManifest();
   const datasets = readDatasetRegistry();
-  const runDetails = readRunDetails();
+  const retrieverReg = readRetrieverRegistry();
+  const runDetails = readRunDetails(retrieverReg);
 
-  const { datasetCounts, methodCounts, modelCounts } = buildViews(rows, datasets);
+  // Counts.
+  const datasetCounts = new Map<string, number>();
+  const methodCounts = new Map<string, number>();
+  const modelCounts = new Map<string, number>();
+  const retrieverCounts = new Map<string, number>();
+  const seen = new Set<string>();
+  const methodDisplay = new Map<string, string>();
+  for (const r of rows) {
+    if (seen.has(r.run_id)) continue;
+    seen.add(r.run_id);
+    const lm = logicalMethod(r.method_id, r.method_params_json);
+    methodDisplay.set(lm.id, lm.display);
+    datasetCounts.set(r.dataset_id, (datasetCounts.get(r.dataset_id) ?? 0) + 1);
+    methodCounts.set(lm.id, (methodCounts.get(lm.id) ?? 0) + 1);
+    modelCounts.set(r.model, (modelCounts.get(r.model) ?? 0) + 1);
+    retrieverCounts.set(r.retriever_id, (retrieverCounts.get(r.retriever_id) ?? 0) + 1);
+  }
+
+  // Per-X views (dataset, model, method, retriever).
+  buildPerDatasetViews(rows, datasets);
+  buildPerModelViews(rows);
+  buildPerMethodViews(rows);
+  buildPerRetrieverViews(rows);
+
+  // Home matrix.
+  writeJSON(path.join(OUT_DIR, "matrix.json"), buildHomeMatrix(rows, datasets));
 
   // Top-level shards.
   writeJSON(path.join(OUT_DIR, "overview.json"), {
@@ -320,6 +540,7 @@ function main() {
     dataset_count: Object.keys(datasets).length,
     method_count: methodCounts.size,
     model_count: modelCounts.size,
+    retriever_count: retrieverCounts.size,
   });
 
   const datasetList: DatasetEntry[] = Object.values(datasets).map((d) => ({
@@ -330,21 +551,31 @@ function main() {
   writeJSON(path.join(OUT_DIR, "datasets.json"), datasetList);
 
   const methodList = Array.from(methodCounts.entries())
-    .map(([id, run_count]) => ({ id, run_count }))
+    .map(([id, run_count]) => ({ id, run_count, display: methodDisplay.get(id) ?? id }))
     .sort((a, b) => a.id.localeCompare(b.id));
   writeJSON(path.join(OUT_DIR, "methods.json"), methodList);
 
   const modelList = Array.from(modelCounts.entries())
-    .map(([id, run_count]) => ({ id, run_count }))
+    .map(([id, run_count]) => ({ id, run_count, slug: encodePathSegment(id) }))
     .sort((a, b) => a.id.localeCompare(b.id));
   writeJSON(path.join(OUT_DIR, "models.json"), modelList);
+
+  const retrieverList: RetrieverEntry[] = Array.from(retrieverCounts.entries())
+    .map(([id, run_count]) => ({
+      id,
+      display_name: retrieverReg[id]?.display_name ?? id,
+      paradigm: retrieverReg[id]?.paradigm ?? "",
+      run_count,
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+  writeJSON(path.join(OUT_DIR, "retrievers.json"), retrieverList);
 
   writeJSON(path.join(OUT_DIR, "runs.json"), runDetails);
 
   console.log(
     `build-data: ${rows.length} rows, ${Object.keys(runDetails).length} runs, ` +
       `${Object.keys(datasets).length} datasets, ${methodList.length} methods, ` +
-      `${modelList.length} models`,
+      `${modelList.length} models, ${retrieverList.length} retrievers`,
   );
 }
 

--- a/reproducibility/site/src/layouts/Default.astro
+++ b/reproducibility/site/src/layouts/Default.astro
@@ -17,6 +17,7 @@ const navLinks = [
   { label: "Datasets", href: "/datasets/" },
   { label: "Methods", href: "/methods/" },
   { label: "Models", href: "/models/" },
+  { label: "Retrievers", href: "/retrievers/" },
   { label: "Cite", href: "/cite/" },
   { label: "About", href: "/about" },
   { label: "Toolkit", href: "https://querygym.com", external: true, newTab: true },

--- a/reproducibility/site/src/pages/datasets/[id].astro
+++ b/reproducibility/site/src/pages/datasets/[id].astro
@@ -53,7 +53,7 @@ const metricCols: string[] = view?.metric_columns ?? datasetMeta?.eval_metrics ?
             <tr class="border-b border-qg-border text-left">
               <th class="px-3 py-2">Method</th>
               <th class="px-3 py-2">Model</th>
-              <th class="px-3 py-2">Params</th>
+              <th class="px-3 py-2">Retriever</th>
               {metricCols.map((m) => (
                 <th class="px-3 py-2 text-right qg-mono text-xs">{m}</th>
               ))}
@@ -63,11 +63,9 @@ const metricCols: string[] = view?.metric_columns ?? datasetMeta?.eval_metrics ?
           <tbody>
             {runs.map((r: any) => (
               <tr class="border-b border-qg-border/60 hover:bg-qg-bg-soft">
-                <td class="px-3 py-2 font-medium">{r.method_id}</td>
+                <td class="px-3 py-2 font-medium">{r.method_display ?? r.method_id}</td>
                 <td class="px-3 py-2 qg-mono text-xs">{r.model}</td>
-                <td class="px-3 py-2 qg-mono text-xs text-qg-fg-muted">
-                  {r.method_params_json}
-                </td>
+                <td class="px-3 py-2 text-xs">{r.retriever_display ?? r.retriever_id}</td>
                 {metricCols.map((m) => (
                   <td class="px-3 py-2 text-right">
                     <MetricCell value={r.metrics?.[m]} best={r.best_for?.[m]} />

--- a/reproducibility/site/src/pages/index.astro
+++ b/reproducibility/site/src/pages/index.astro
@@ -1,68 +1,206 @@
 ---
 import Default from "../layouts/Default.astro";
-import EmptyState from "../components/EmptyState.astro";
 import Stat from "../components/Stat.astro";
 import overview from "../data/overview.json";
-import datasets from "../data/datasets.json";
+import matrix from "../data/matrix.json";
+import retrievers from "../data/retrievers.json";
+import models from "../data/models.json";
 
 const populated = overview.run_count > 0;
-const featured = datasets.filter((d: any) => d.run_count > 0).slice(0, 6);
+
+// Short dataset labels for the matrix header.
+const SHORT: Record<string, string> = {
+  "msmarco-v1-passage.trecdl2019": "DL 2019",
+  "msmarco-v1-passage.trecdl2020": "DL 2020",
+  "msmarco-v1-passage.dlhard":     "DL-HARD",
+  "beir-v1.0.0-scifact":           "SciFact",
+  "beir-v1.0.0-arguana":           "ArguAna",
+  "beir-v1.0.0-trec-covid":        "COVID",
+  "beir-v1.0.0-fiqa":              "FiQA",
+  "beir-v1.0.0-dbpedia-entity":    "DBPedia",
+  "beir-v1.0.0-trec-news":         "News",
+};
+
+const METRIC_LABEL: Record<string, string> = {
+  ndcg_cut_10: "nDCG@10",
+  recall_1000: "R@1k",
+  recall_100:  "R@100",
+};
+
+const rows = [...matrix.rows].sort((a: any, b: any) => {
+  if (a.method_id !== b.method_id) return a.method_id.localeCompare(b.method_id);
+  if (a.model !== b.model) return a.model.localeCompare(b.model);
+  return a.retriever_id.localeCompare(b.retriever_id);
+});
+
+const datasetCols = matrix.dataset_columns;
 ---
 
 <Default
-  title="Home"
-  description="QueryGym leaderboard — query reformulation methods × LLMs across IR benchmarks."
+  title="Leaderboard"
+  description="QueryGym reproducibility leaderboard — query reformulation methods × LLMs × retrievers across IR benchmarks."
 >
-  <section class="mb-10">
+  <section class="mb-8">
     <h1 class="text-3xl font-bold md:text-4xl">QueryGym Leaderboard</h1>
     <p class="mt-3 max-w-3xl text-qg-fg-muted">
-      Reproducible LLM-based query reformulation results across BEIR, MS MARCO,
-      and TREC DL benchmarks. Every row is backed by a committed JSON, a TREC
-      run file, and the reformulated queries — verifiable from a fresh clone.
+      Reproducible LLM-based query reformulation results across MS MARCO DL,
+      DL-HARD, and BEIR — for BM25, SPLADE++, and BGE retrievers. Click any
+      score to see how to reproduce that run.
     </p>
-    <div class="mt-4 flex flex-wrap gap-3 text-sm">
-      <a
-        href="/datasets/"
-        class="rounded-md bg-qg-accent px-4 py-2 font-medium text-white hover:opacity-90"
-        >Browse datasets</a
-      >
-      <a
-        href="/about"
-        class="rounded-md border border-qg-border px-4 py-2 font-medium hover:bg-qg-bg-soft"
-        >How to submit</a
-      >
-    </div>
   </section>
 
-  <section class="mb-10 grid grid-cols-2 gap-4 md:grid-cols-4">
+  <section class="mb-6 grid grid-cols-2 gap-4 md:grid-cols-5">
     <Stat label="Runs" value={overview.run_count} />
-    <Stat label="Datasets" value={overview.dataset_count} />
     <Stat label="Methods" value={overview.method_count} />
     <Stat label="LLMs" value={overview.model_count} />
+    <Stat label="Retrievers" value={overview.retriever_count} />
+    <Stat label="Datasets" value={overview.dataset_count} />
   </section>
 
-  <section>
-    <h2 class="mb-4 text-xl font-semibold">Datasets with results</h2>
-    {
-      populated ? (
-        <ul class="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
-          {featured.map((d: any) => (
-            <li class="rounded-lg border border-qg-border bg-qg-bg-soft p-4 hover:border-qg-accent">
-              <a href={`/datasets/${d.id}`} class="block">
-                <div class="font-semibold">{d.name}</div>
-                <div class="mt-1 text-xs text-qg-fg-muted">
-                  {d.run_count} run{d.run_count === 1 ? "" : "s"} · {d.eval_metrics.join(", ")}
-                </div>
-              </a>
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <EmptyState
-          title="No SIGIR runs landed yet"
-          body="The schema is locked and the pipeline is live. Once the SIGIR backfill PR lands, results appear here automatically."
-        />
-      )
-    }
-  </section>
+  {
+    populated && (
+      <section class="mb-4">
+        <div class="flex flex-wrap items-center gap-3 text-sm">
+          <span class="text-qg-fg-muted">Retriever:</span>
+          <div id="qg-filter-retriever" class="flex flex-wrap gap-1.5">
+            <button data-value="" class="qg-chip qg-chip-active">All</button>
+            {retrievers.map((r: any) => (
+              <button data-value={r.id} class="qg-chip">{r.display_name}</button>
+            ))}
+          </div>
+          <span class="ml-4 text-qg-fg-muted">Model:</span>
+          <div id="qg-filter-model" class="flex flex-wrap gap-1.5">
+            <button data-value="" class="qg-chip qg-chip-active">All</button>
+            {models.map((m: any) => (
+              <button data-value={m.id} class="qg-chip">{m.id}</button>
+            ))}
+          </div>
+          <span class="ml-4 text-qg-fg-muted">Metric:</span>
+          <div id="qg-filter-metric" class="flex flex-wrap gap-1.5">
+            <button data-value="primary" class="qg-chip qg-chip-active">nDCG@10</button>
+            <button data-value="secondary" class="qg-chip">Recall</button>
+          </div>
+        </div>
+      </section>
+    )
+  }
+
+  {
+    populated ? (
+      <section class="overflow-x-auto rounded border border-qg-border">
+        <table id="qg-matrix" class="w-full text-sm">
+          <thead class="bg-qg-bg-soft text-xs uppercase tracking-wide text-qg-fg-muted">
+            <tr>
+              <th class="px-3 py-2 text-left">Method</th>
+              <th class="px-3 py-2 text-left">Model</th>
+              <th class="px-3 py-2 text-left">Retriever</th>
+              {datasetCols.map((d: any) => (
+                <th
+                  class="qg-mono px-3 py-2 text-right text-xs"
+                  title={d.id}
+                >
+                  <span class="qg-col-label-primary">
+                    {SHORT[d.id] ?? d.name}
+                    <span class="text-qg-fg-muted"> / {METRIC_LABEL[d.primary_metric] ?? d.primary_metric}</span>
+                  </span>
+                  <span class="qg-col-label-secondary hidden">
+                    {SHORT[d.id] ?? d.name}
+                    <span class="text-qg-fg-muted"> / {METRIC_LABEL[d.secondary_metric] ?? d.secondary_metric}</span>
+                  </span>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row: any) => (
+              <tr
+                class="border-t border-qg-border/60 hover:bg-qg-bg-soft qg-matrix-row"
+                data-method={row.method_id}
+                data-model={row.model}
+                data-retriever={row.retriever_id}
+              >
+                <td class="px-3 py-2 font-medium">{row.method_display ?? row.method_id}</td>
+                <td class="px-3 py-2 qg-mono text-xs">{row.model}</td>
+                <td class="px-3 py-2 text-xs">{row.retriever_display ?? row.retriever_id}</td>
+                {datasetCols.map((d: any) => {
+                  const cell = row.values?.[d.id] ?? {};
+                  const runId = row.run_ids?.[d.id];
+                  const primary = cell[d.primary_metric];
+                  const secondary = d.secondary_metric ? cell[d.secondary_metric] : null;
+                  return (
+                    <td class="qg-mono px-3 py-2 text-right tabular-nums">
+                      {runId ? (
+                        <a class="hover:text-qg-accent hover:underline" href={`/runs/${runId}`} title="View run + reproduce">
+                          <span class={`qg-cell-primary ${primary?.best ? "font-bold text-qg-accent" : ""}`}>
+                            {primary !== undefined ? primary.value.toFixed(3) : "—"}
+                          </span>
+                          {secondary && (
+                            <span class={`qg-cell-secondary hidden ${secondary.best ? "font-bold text-qg-accent" : ""}`}>
+                              {secondary.value.toFixed(3)}
+                            </span>
+                          )}
+                        </a>
+                      ) : (
+                        <span class="text-qg-fg-muted">—</span>
+                      )}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    ) : (
+      <div class="mt-8 rounded-lg border border-qg-border bg-qg-bg-soft p-6 text-qg-fg-muted">
+        No runs yet. The matrix will populate when results land.
+      </div>
+    )
+  }
 </Default>
+
+<style>
+  .qg-chip {
+    @apply rounded-full border border-qg-border bg-qg-bg-soft px-3 py-1 text-xs font-medium text-qg-fg-muted hover:border-qg-accent;
+  }
+  .qg-chip-active {
+    @apply border-qg-accent bg-qg-accent text-white hover:border-qg-accent;
+  }
+</style>
+
+<script>
+  const tbody = document.querySelector<HTMLTableSectionElement>("#qg-matrix tbody");
+  if (tbody) {
+    const filters = { retriever: "", model: "", metric: "primary" };
+
+    function applyFilters() {
+      tbody.querySelectorAll<HTMLTableRowElement>(".qg-matrix-row").forEach((tr) => {
+        const okR = !filters.retriever || tr.dataset.retriever === filters.retriever;
+        const okM = !filters.model || tr.dataset.model === filters.model;
+        tr.style.display = okR && okM ? "" : "none";
+      });
+      const primaryShown = filters.metric === "primary";
+      document.querySelectorAll(".qg-col-label-primary").forEach((el) => el.classList.toggle("hidden", !primaryShown));
+      document.querySelectorAll(".qg-col-label-secondary").forEach((el) => el.classList.toggle("hidden", primaryShown));
+      document.querySelectorAll(".qg-cell-primary").forEach((el) => el.classList.toggle("hidden", !primaryShown));
+      document.querySelectorAll(".qg-cell-secondary").forEach((el) => el.classList.toggle("hidden", primaryShown));
+    }
+
+    function wireGroup(groupId: string, key: "retriever" | "model" | "metric") {
+      const group = document.getElementById(groupId);
+      if (!group) return;
+      group.querySelectorAll<HTMLButtonElement>("button").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          group.querySelectorAll("button").forEach((b) => b.classList.remove("qg-chip-active"));
+          btn.classList.add("qg-chip-active");
+          filters[key] = btn.dataset.value ?? "";
+          applyFilters();
+        });
+      });
+    }
+
+    wireGroup("qg-filter-retriever", "retriever");
+    wireGroup("qg-filter-model", "model");
+    wireGroup("qg-filter-metric", "metric");
+  }
+</script>

--- a/reproducibility/site/src/pages/methods/[id].astro
+++ b/reproducibility/site/src/pages/methods/[id].astro
@@ -1,0 +1,101 @@
+---
+import Default from "../../layouts/Default.astro";
+import EmptyState from "../../components/EmptyState.astro";
+import methods from "../../data/methods.json";
+
+const shards = import.meta.glob<{ default: any }>(
+  "../../data/views/method-*.json",
+  { eager: true },
+);
+function shardFor(id: string): any | null {
+  const key = Object.keys(shards).find((k) => k.endsWith(`/method-${id}.json`));
+  return key ? shards[key].default : null;
+}
+
+export async function getStaticPaths() {
+  const list = (await import("../../data/methods.json")).default as any[];
+  return list.map((m) => ({ params: { id: m.id } }));
+}
+
+const { id } = Astro.params;
+const view = shardFor(id!);
+const meta = methods.find((m: any) => m.id === id);
+const rows = view?.rows ?? [];
+
+const SHORT: Record<string, string> = {
+  "msmarco-v1-passage.trecdl2019": "DL 2019",
+  "msmarco-v1-passage.trecdl2020": "DL 2020",
+  "msmarco-v1-passage.dlhard":     "DL-HARD",
+  "beir-v1.0.0-scifact":           "SciFact",
+  "beir-v1.0.0-arguana":           "ArguAna",
+  "beir-v1.0.0-trec-covid":        "COVID",
+  "beir-v1.0.0-fiqa":              "FiQA",
+  "beir-v1.0.0-dbpedia-entity":    "DBPedia",
+  "beir-v1.0.0-trec-news":         "News",
+};
+const METRIC_LABEL: Record<string, string> = {
+  ndcg_cut_10: "nDCG@10", recall_1000: "R@1k", recall_100: "R@100",
+};
+
+const datasetCols = (await import("../../data/matrix.json")).default.dataset_columns;
+
+const title = view?.method_display ?? meta?.display ?? id ?? "Method";
+---
+
+<Default title={title} description={`Per-method leaderboard for ${title}.`}>
+  <a href="/methods/" class="text-sm text-qg-fg-muted hover:text-qg-fg">← All methods</a>
+  <h1 class="mt-2 text-2xl font-bold md:text-3xl">{title}</h1>
+  <div class="mt-1 qg-mono text-sm text-qg-fg-muted">{id}</div>
+  <div class="mt-1 text-sm text-qg-fg-muted">{rows.length} model × retriever combinations</div>
+
+  {
+    rows.length === 0 ? (
+      <div class="mt-8">
+        <EmptyState title="No runs for this method yet" body="" />
+      </div>
+    ) : (
+      <section class="mt-6 overflow-x-auto rounded border border-qg-border">
+        <table class="w-full text-sm">
+          <thead class="bg-qg-bg-soft text-xs uppercase tracking-wide text-qg-fg-muted">
+            <tr>
+              <th class="px-3 py-2 text-left">Model</th>
+              <th class="px-3 py-2 text-left">Retriever</th>
+              {datasetCols.map((d: any) => (
+                <th class="qg-mono px-3 py-2 text-right text-xs" title={d.id}>
+                  {SHORT[d.id] ?? d.name}
+                  <span class="text-qg-fg-muted"> / {METRIC_LABEL[d.primary_metric] ?? d.primary_metric}</span>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row: any) => (
+              <tr class="border-t border-qg-border/60 hover:bg-qg-bg-soft">
+                <td class="px-3 py-2 qg-mono text-xs">{row.model}</td>
+                <td class="px-3 py-2 text-xs">{row.retriever_display ?? row.retriever_id}</td>
+                {datasetCols.map((d: any) => {
+                  const cell = row.values?.[d.id] ?? {};
+                  const runId = row.run_ids?.[d.id];
+                  const primary = cell[d.primary_metric];
+                  return (
+                    <td class="qg-mono px-3 py-2 text-right tabular-nums">
+                      {runId && primary !== undefined ? (
+                        <a class="hover:text-qg-accent hover:underline" href={`/runs/${runId}`}>
+                          <span class={primary.best ? "font-bold text-qg-accent" : ""}>
+                            {primary.value.toFixed(3)}
+                          </span>
+                        </a>
+                      ) : (
+                        <span class="text-qg-fg-muted">—</span>
+                      )}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    )
+  }
+</Default>

--- a/reproducibility/site/src/pages/methods/index.astro
+++ b/reproducibility/site/src/pages/methods/index.astro
@@ -17,11 +17,14 @@ import methods from "../../data/methods.json";
     ) : (
       <ul class="mt-6 grid gap-3 md:grid-cols-2 lg:grid-cols-3">
         {methods.map((m: any) => (
-          <li class="rounded-lg border border-qg-border p-4 hover:bg-qg-bg-soft">
-            <div class="font-semibold qg-mono">{m.id}</div>
-            <div class="mt-1 text-xs text-qg-fg-muted">
-              {m.run_count} run{m.run_count === 1 ? "" : "s"}
-            </div>
+          <li class="rounded-lg border border-qg-border p-4 hover:bg-qg-bg-soft hover:border-qg-accent">
+            <a href={`/methods/${m.id}`} class="block">
+              <div class="font-semibold">{m.display ?? m.id}</div>
+              <div class="mt-1 qg-mono text-xs text-qg-fg-muted">{m.id}</div>
+              <div class="mt-1 text-xs text-qg-fg-muted">
+                {m.run_count} run{m.run_count === 1 ? "" : "s"}
+              </div>
+            </a>
           </li>
         ))}
       </ul>

--- a/reproducibility/site/src/pages/models/[id].astro
+++ b/reproducibility/site/src/pages/models/[id].astro
@@ -1,0 +1,102 @@
+---
+import Default from "../../layouts/Default.astro";
+import EmptyState from "../../components/EmptyState.astro";
+import models from "../../data/models.json";
+
+const shards = import.meta.glob<{ default: any }>(
+  "../../data/views/model-*.json",
+  { eager: true },
+);
+function shardFor(slug: string): any | null {
+  const key = Object.keys(shards).find((k) => k.endsWith(`/model-${slug}.json`));
+  return key ? shards[key].default : null;
+}
+
+export async function getStaticPaths() {
+  const list = (await import("../../data/models.json")).default as any[];
+  return list.map((m) => ({ params: { id: m.slug } }));
+}
+
+const { id } = Astro.params;
+const view = shardFor(id!);
+const meta = models.find((m: any) => m.slug === id);
+const rows = view?.rows ?? [];
+
+// Same dataset-label/metric-label tables as the home page.
+const SHORT: Record<string, string> = {
+  "msmarco-v1-passage.trecdl2019": "DL 2019",
+  "msmarco-v1-passage.trecdl2020": "DL 2020",
+  "msmarco-v1-passage.dlhard":     "DL-HARD",
+  "beir-v1.0.0-scifact":           "SciFact",
+  "beir-v1.0.0-arguana":           "ArguAna",
+  "beir-v1.0.0-trec-covid":        "COVID",
+  "beir-v1.0.0-fiqa":              "FiQA",
+  "beir-v1.0.0-dbpedia-entity":    "DBPedia",
+  "beir-v1.0.0-trec-news":         "News",
+};
+const METRIC_LABEL: Record<string, string> = {
+  ndcg_cut_10: "nDCG@10", recall_1000: "R@1k", recall_100: "R@100",
+};
+
+// Dataset columns from the shared home matrix shape (re-derive from rows).
+const datasetCols = (await import("../../data/matrix.json")).default.dataset_columns;
+
+const title = view?.model ?? id ?? "Model";
+---
+
+<Default title={title} description={`Per-LLM leaderboard for ${title}.`}>
+  <a href="/models/" class="text-sm text-qg-fg-muted hover:text-qg-fg">← All models</a>
+  <h1 class="mt-2 text-2xl font-bold md:text-3xl qg-mono">{title}</h1>
+  <div class="mt-1 text-sm text-qg-fg-muted">{rows.length} method × retriever combinations</div>
+
+  {
+    rows.length === 0 ? (
+      <div class="mt-8">
+        <EmptyState title="No runs for this model yet" body="" />
+      </div>
+    ) : (
+      <section class="mt-6 overflow-x-auto rounded border border-qg-border">
+        <table class="w-full text-sm">
+          <thead class="bg-qg-bg-soft text-xs uppercase tracking-wide text-qg-fg-muted">
+            <tr>
+              <th class="px-3 py-2 text-left">Method</th>
+              <th class="px-3 py-2 text-left">Retriever</th>
+              {datasetCols.map((d: any) => (
+                <th class="qg-mono px-3 py-2 text-right text-xs" title={d.id}>
+                  {SHORT[d.id] ?? d.name}
+                  <span class="text-qg-fg-muted"> / {METRIC_LABEL[d.primary_metric] ?? d.primary_metric}</span>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row: any) => (
+              <tr class="border-t border-qg-border/60 hover:bg-qg-bg-soft">
+                <td class="px-3 py-2 font-medium">{row.method_display ?? row.method_id}</td>
+                <td class="px-3 py-2 text-xs">{row.retriever_display ?? row.retriever_id}</td>
+                {datasetCols.map((d: any) => {
+                  const cell = row.values?.[d.id] ?? {};
+                  const runId = row.run_ids?.[d.id];
+                  const primary = cell[d.primary_metric];
+                  return (
+                    <td class="qg-mono px-3 py-2 text-right tabular-nums">
+                      {runId && primary !== undefined ? (
+                        <a class="hover:text-qg-accent hover:underline" href={`/runs/${runId}`}>
+                          <span class={primary.best ? "font-bold text-qg-accent" : ""}>
+                            {primary.value.toFixed(3)}
+                          </span>
+                        </a>
+                      ) : (
+                        <span class="text-qg-fg-muted">—</span>
+                      )}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    )
+  }
+</Default>

--- a/reproducibility/site/src/pages/models/index.astro
+++ b/reproducibility/site/src/pages/models/index.astro
@@ -16,11 +16,13 @@ import models from "../../data/models.json";
     ) : (
       <ul class="mt-6 grid gap-3 md:grid-cols-2 lg:grid-cols-3">
         {models.map((m: any) => (
-          <li class="rounded-lg border border-qg-border p-4 hover:bg-qg-bg-soft">
-            <div class="font-semibold qg-mono">{m.id}</div>
-            <div class="mt-1 text-xs text-qg-fg-muted">
-              {m.run_count} run{m.run_count === 1 ? "" : "s"}
-            </div>
+          <li class="rounded-lg border border-qg-border p-4 hover:bg-qg-bg-soft hover:border-qg-accent">
+            <a href={`/models/${m.slug}`} class="block">
+              <div class="font-semibold qg-mono">{m.id}</div>
+              <div class="mt-1 text-xs text-qg-fg-muted">
+                {m.run_count} run{m.run_count === 1 ? "" : "s"}
+              </div>
+            </a>
           </li>
         ))}
       </ul>

--- a/reproducibility/site/src/pages/retrievers/[id].astro
+++ b/reproducibility/site/src/pages/retrievers/[id].astro
@@ -1,0 +1,100 @@
+---
+import Default from "../../layouts/Default.astro";
+import EmptyState from "../../components/EmptyState.astro";
+import retrievers from "../../data/retrievers.json";
+
+const shards = import.meta.glob<{ default: any }>(
+  "../../data/views/retriever-*.json",
+  { eager: true },
+);
+function shardFor(id: string): any | null {
+  const key = Object.keys(shards).find((k) => k.endsWith(`/retriever-${id}.json`));
+  return key ? shards[key].default : null;
+}
+
+export async function getStaticPaths() {
+  const list = (await import("../../data/retrievers.json")).default as any[];
+  return list.map((r) => ({ params: { id: r.id } }));
+}
+
+const { id } = Astro.params;
+const view = shardFor(id!);
+const meta = retrievers.find((r: any) => r.id === id);
+const rows = view?.rows ?? [];
+
+const SHORT: Record<string, string> = {
+  "msmarco-v1-passage.trecdl2019": "DL 2019",
+  "msmarco-v1-passage.trecdl2020": "DL 2020",
+  "msmarco-v1-passage.dlhard":     "DL-HARD",
+  "beir-v1.0.0-scifact":           "SciFact",
+  "beir-v1.0.0-arguana":           "ArguAna",
+  "beir-v1.0.0-trec-covid":        "COVID",
+  "beir-v1.0.0-fiqa":              "FiQA",
+  "beir-v1.0.0-dbpedia-entity":    "DBPedia",
+  "beir-v1.0.0-trec-news":         "News",
+};
+const METRIC_LABEL: Record<string, string> = {
+  ndcg_cut_10: "nDCG@10", recall_1000: "R@1k", recall_100: "R@100",
+};
+
+const datasetCols = (await import("../../data/matrix.json")).default.dataset_columns;
+const title = meta?.display_name ?? id ?? "Retriever";
+---
+
+<Default title={title} description={`Per-retriever leaderboard for ${title}.`}>
+  <a href="/retrievers/" class="text-sm text-qg-fg-muted hover:text-qg-fg">← All retrievers</a>
+  <h1 class="mt-2 text-2xl font-bold md:text-3xl">{title}</h1>
+  <div class="mt-1 qg-mono text-sm text-qg-fg-muted">{id} · {meta?.paradigm}</div>
+  <div class="mt-1 text-sm text-qg-fg-muted">{rows.length} method × model combinations</div>
+
+  {
+    rows.length === 0 ? (
+      <div class="mt-8">
+        <EmptyState title="No runs for this retriever yet" body="" />
+      </div>
+    ) : (
+      <section class="mt-6 overflow-x-auto rounded border border-qg-border">
+        <table class="w-full text-sm">
+          <thead class="bg-qg-bg-soft text-xs uppercase tracking-wide text-qg-fg-muted">
+            <tr>
+              <th class="px-3 py-2 text-left">Method</th>
+              <th class="px-3 py-2 text-left">Model</th>
+              {datasetCols.map((d: any) => (
+                <th class="qg-mono px-3 py-2 text-right text-xs" title={d.id}>
+                  {SHORT[d.id] ?? d.name}
+                  <span class="text-qg-fg-muted"> / {METRIC_LABEL[d.primary_metric] ?? d.primary_metric}</span>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row: any) => (
+              <tr class="border-t border-qg-border/60 hover:bg-qg-bg-soft">
+                <td class="px-3 py-2 font-medium">{row.method_display ?? row.method_id}</td>
+                <td class="px-3 py-2 qg-mono text-xs">{row.model}</td>
+                {datasetCols.map((d: any) => {
+                  const cell = row.values?.[d.id] ?? {};
+                  const runId = row.run_ids?.[d.id];
+                  const primary = cell[d.primary_metric];
+                  return (
+                    <td class="qg-mono px-3 py-2 text-right tabular-nums">
+                      {runId && primary !== undefined ? (
+                        <a class="hover:text-qg-accent hover:underline" href={`/runs/${runId}`}>
+                          <span class={primary.best ? "font-bold text-qg-accent" : ""}>
+                            {primary.value.toFixed(3)}
+                          </span>
+                        </a>
+                      ) : (
+                        <span class="text-qg-fg-muted">—</span>
+                      )}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    )
+  }
+</Default>

--- a/reproducibility/site/src/pages/retrievers/index.astro
+++ b/reproducibility/site/src/pages/retrievers/index.astro
@@ -1,0 +1,28 @@
+---
+import Default from "../../layouts/Default.astro";
+import retrievers from "../../data/retrievers.json";
+---
+
+<Default title="Retrievers" description="All retrievers tracked in the leaderboard.">
+  <h1 class="text-2xl font-bold md:text-3xl">Retrievers</h1>
+  <p class="mt-2 text-qg-fg-muted">
+    Each retriever has its own per-(method × model) leaderboard.
+  </p>
+
+  <ul class="mt-6 grid gap-3 md:grid-cols-3">
+    {
+      retrievers.map((r: any) => (
+        <li class="rounded-lg border border-qg-border p-4 hover:bg-qg-bg-soft">
+          <a href={`/retrievers/${r.id}`} class="block">
+            <div class="flex items-baseline justify-between gap-2">
+              <span class="font-semibold">{r.display_name}</span>
+              <span class="text-xs text-qg-fg-muted">{r.run_count} runs</span>
+            </div>
+            <div class="mt-1 qg-mono text-xs text-qg-fg-muted">{r.id}</div>
+            <div class="mt-2 text-xs text-qg-fg-muted">{r.paradigm}</div>
+          </a>
+        </li>
+      ))
+    }
+  </ul>
+</Default>

--- a/reproducibility/site/src/pages/runs/[run_id].astro
+++ b/reproducibility/site/src/pages/runs/[run_id].astro
@@ -1,6 +1,7 @@
 ---
 import Default from "../../layouts/Default.astro";
 import Field from "../../components/Field.astro";
+import CodeBlock from "../../components/CodeBlock.astro";
 import runs from "../../data/runs.json";
 
 export async function getStaticPaths() {
@@ -10,10 +11,90 @@ export async function getStaticPaths() {
 
 const { run_id } = Astro.params;
 const run = (runs as Record<string, any>)[run_id!];
+
+// Compose the reproduce snippets from the run's config.
+const cfg = (run?.config ?? {}) as any;
+const retrieval = (cfg.retrieval ?? {}) as any;
+const dsCfg = (cfg.dataset_config ?? {}) as any;
+const methodParams = (cfg.method_params ?? {}) as Record<string, unknown>;
+const llm = (cfg.llm_config ?? {}) as Record<string, unknown>;
+
+// Pretty-format method_params for the Python snippet (skipping noise/secrets).
+const FILTERED_PARAM_KEYS = new Set([
+  "judge_rel_mode",
+  "collection_path",
+  "train_queries_path",
+  "train_qrels_path",
+  "dataset_type",
+]);
+const cleanParams: Record<string, unknown> = {};
+for (const [k, v] of Object.entries(methodParams)) {
+  if (!FILTERED_PARAM_KEYS.has(k)) cleanParams[k] = v;
+}
+const paramKwargs = Object.entries(cleanParams)
+  .map(([k, v]) => `    ${k}=${JSON.stringify(v)},`)
+  .join("\n");
+
+const pyReformulate = `import querygym as qg
+
+# 1. Build the reformulator with this run's method + model + params.
+reformulator = qg.create_reformulator(
+    "${run.method_id}",
+    model="${run.model}",
+    temperature=${llm.temperature ?? 1.0},
+    max_tokens=${llm.max_tokens ?? 128},${paramKwargs ? "\n" + paramKwargs : ""}
+)
+
+# 2. Reformulate queries from the dataset's topics file.
+#    (Pyserini topic name: ${dsCfg.topics ?? "<topics>"} ; ${dsCfg.num_queries ?? "?"} queries)
+queries = qg.loaders.load_pyserini_topics("${dsCfg.topics ?? "<topics>"}")
+reformulated = reformulator.reformulate_batch(queries)
+
+# 3. Write the reformulated queries TSV (this becomes --topics for retrieval).
+qg.loaders.save_topics_tsv(reformulated, "reformulated_queries.tsv")
+`;
+
+// Retrieval command depends on retriever paradigm.
+const retrId = retrieval.retriever_id ?? "";
+const paradigm = retrieval.paradigm ?? "";
+const params = (retrieval.params ?? {}) as any;
+const queriesPath = run.artifacts.queries_url
+  ? `# ↑ download from the leaderboard's queries link, or regenerate with the Python above\nreformulated_queries.tsv`
+  : "reformulated_queries.tsv";
+
+let retrievalCmd = "";
+if (paradigm === "lexical") {
+  retrievalCmd = `python -m pyserini.search.lucene \\
+  --threads 16 --batch-size 128 \\
+  --index ${dsCfg.index ?? "<pyserini-index>"} \\
+  --topics reformulated_queries.tsv \\
+  --bm25 --k1 ${params.k1 ?? 0.9} --b ${params.b ?? 0.4} \\
+  --output run.txt \\
+  --hits 1000`;
+} else if (paradigm === "learned_sparse") {
+  retrievalCmd = `python -m pyserini.search.lucene \\
+  --threads 16 --batch-size 128 \\
+  --index ${dsCfg.index ?? "<pyserini-index>"}.splade-pp-ed \\
+  --topics reformulated_queries.tsv \\
+  --encoder ${params.model ?? "naver/splade-cocondenser-ensembledistil"} \\
+  --output run.txt \\
+  --hits 1000 --impact`;
+} else if (paradigm === "dense") {
+  retrievalCmd = `python -m pyserini.search.faiss \\
+  --threads 16 --batch-size 128 \\
+  --index ${dsCfg.index ?? "<pyserini-index>"}.bge-base-en-v1.5 \\
+  --topics reformulated_queries.tsv \\
+  --encoder ${params.encoder ?? "BAAI/bge-base-en-v1.5"} \\
+  --output run.txt \\
+  --hits 1000`;
+}
+
+const trecEvalCmd = `python -m pyserini.eval.trec_eval -c -m ${run.metrics ? Object.keys(run.metrics).join(" -m ").replace(/_/g, ".") : "ndcg_cut.10"} \\
+  ${dsCfg.topics ?? "<qrels>"} run.txt`;
 ---
 
 <Default title={`Run ${run_id?.slice(0, 8)}`} description="Single run detail.">
-  <a href="/datasets/" class="text-sm text-qg-fg-muted hover:text-qg-fg">← Datasets</a>
+  <a href="/" class="text-sm text-qg-fg-muted hover:text-qg-fg">← Leaderboard</a>
   <h1 class="mt-2 text-2xl font-bold md:text-3xl">Run detail</h1>
   <div class="mt-1 qg-mono text-sm text-qg-fg-muted">{run_id}</div>
 
@@ -21,9 +102,9 @@ const run = (runs as Record<string, any>)[run_id!];
     <Field label="Dataset" value={run.dataset_id} />
     <Field label="Method" value={run.method_id} />
     <Field label="Model" value={run.model} />
+    <Field label="Retriever" value={`${run.retriever_display ?? run.retriever_id ?? "—"} (${run.paradigm ?? "?"})`} />
     <Field label="params_hash" value={run.params_hash} />
     <Field label="Queries" value={run.num_queries} />
-    <Field label="Total time (s)" value={run.total_time_seconds.toFixed(1)} />
   </section>
 
   <section class="mt-8">
@@ -40,7 +121,21 @@ const run = (runs as Record<string, any>)[run_id!];
     </table>
   </section>
 
-  <section class="mt-8">
+  <section class="mt-10">
+    <h2 class="mb-3 text-lg font-semibold">Reproduce this run</h2>
+    <p class="mb-4 text-sm text-qg-fg-muted">
+      Two steps: (1) reformulate the queries with QueryGym, (2) run retrieval with Pyserini.
+    </p>
+    <div class="space-y-4">
+      <CodeBlock filename="reformulate.py" language="python">{pyReformulate}</CodeBlock>
+      {retrievalCmd && (
+        <CodeBlock filename={`retrieve (${run.retriever_display ?? run.retriever_id})`} language="bash">{retrievalCmd}</CodeBlock>
+      )}
+      <CodeBlock filename="evaluate (trec_eval)" language="bash">{trecEvalCmd}</CodeBlock>
+    </div>
+  </section>
+
+  <section class="mt-10">
     <h2 class="mb-3 text-lg font-semibold">Artifacts</h2>
     <ul class="space-y-1 text-sm">
       <li>
@@ -48,22 +143,42 @@ const run = (runs as Record<string, any>)[run_id!];
           summary JSON ↗
         </a>
       </li>
-      <li>
-        <a class="text-qg-accent hover:underline" href={run.artifacts.run_file_url} target="_blank" rel="noopener">
-          TREC run.txt ↗
-        </a>
-      </li>
-      <li>
-        <a class="text-qg-accent hover:underline" href={run.artifacts.queries_url} target="_blank" rel="noopener">
-          reformulated queries.tsv ↗
-        </a>
-      </li>
+      {run.artifacts.queries_url && (
+        <li>
+          <a class="text-qg-accent hover:underline" href={run.artifacts.queries_url} target="_blank" rel="noopener">
+            reformulated queries.tsv ↗
+          </a>
+        </li>
+      )}
+      {run.artifacts.run_file_url && (
+        <li>
+          <a class="text-qg-accent hover:underline" href={run.artifacts.run_file_url} target="_blank" rel="noopener">
+            TREC run.txt ↗
+          </a>
+        </li>
+      )}
     </ul>
   </section>
 
-  <section class="mt-8">
+  <section class="mt-10">
     <h2 class="mb-3 text-lg font-semibold">Config</h2>
     <pre class="overflow-x-auto rounded bg-qg-bg-soft p-4 text-xs"><code>{JSON.stringify(run.config, null, 2)}</code></pre>
   </section>
 </Default>
 
+<script>
+  document.querySelectorAll<HTMLButtonElement>(".qg-copy-btn").forEach((btn) => {
+    if (btn.dataset.qgWired === "1") return;
+    btn.dataset.qgWired = "1";
+    btn.addEventListener("click", () => {
+      const pre = btn.closest("div")?.nextElementSibling as HTMLElement | null;
+      const code = pre?.querySelector("code");
+      if (!code) return;
+      navigator.clipboard.writeText(code.textContent ?? "").then(() => {
+        const original = btn.textContent;
+        btn.textContent = "copied";
+        setTimeout(() => (btn.textContent = original ?? "copy"), 1200);
+      });
+    });
+  });
+</script>


### PR DESCRIPTION
## Summary

Full UI redesign of `leaderboard.querygym.com`.

**Home page** is now a single sortable matrix table — rows are `(method × model × retriever)` (120 combinations), columns are `dataset × metric`. Filter chips for retriever and model; chip toggle between nDCG@10 (default) and recall. Best-in-column cells are bolded. Every cell links to the per-run page.

**Per-dataset table** (`/datasets/{id}`) drops the wide `params` column that was pushing the table off-screen; gains a `Retriever` column.

**New per-axis detail pages:**

| Path | What it shows |
|---|---|
| `/models/{slug}` | Methods × retrievers for one LLM |
| `/methods/{id}` | Models × retrievers for one method (each `Q2D-ZS/FS/CoT` is its own page) |
| `/retrievers/` | Index of all retrievers |
| `/retrievers/{id}` | Methods × models for one retriever |

**Per-run page** (`/runs/{id}`) gains a **"Reproduce this run"** section: three copyable code blocks (QueryGym Python reformulation, Pyserini retrieval per retriever, `trec_eval`). Each block has a copy button and wraps inside its panel — no horizontal scroll. Artifact links render only when present.

**Plumbing in `build-data.ts`:**

- Reads `retriever_registry.yaml` for display names + paradigms.
- Emits `matrix.json`, `retrievers.json`, and per-model/method/retriever view shards.
- A `logicalMethod` helper folds noisy legacy params (e.g. extra `judge_rel_mode`, machine-local paths) and surfaces `query2doc`'s mode variants (`zs`/`fs`/`cot`) as distinct logical methods. Within each axis cell, multiple legacy variants are deduped by max metric value.

## Test Plan

- [x] `pnpm -F @qg/leaderboard build` — clean, 1112 pages (+17 from new per-axis pages).
- [x] `build-data` produces 120 matrix rows (10 methods × 4 models × 3 retrievers).
- [x] After merge: CF Pages auto-deploys; verify matrix renders, filters work, per-axis pages exist, run-detail Reproduce block shows the right Pyserini command per retriever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)