### PR TITLE
leaderboard: short model labels, recall toggle for BEIR, sortable+searchable tables

### DIFF
--- a/reproducibility/site/scripts/build-data.ts
+++ b/reproducibility/site/scripts/build-data.ts
@@ -98,6 +98,7 @@ interface RunDetail {
   retriever_id: string;
   retriever_display: string;
   paradigm: string;
+  model_display: string;
   metrics: Record<string, number>;
   config: Record<string, unknown>;
   timing: Record<string, number>;
@@ -200,6 +201,7 @@ function readRunDetails(retrievers: Record<string, { display_name: string; parad
       dataset_id: payload.pipeline.dataset_id,
       method_id: payload.pipeline.method_id,
       model: payload.pipeline.model,
+      model_display: displayModel(payload.pipeline.model),
       retriever_id: retrId,
       retriever_display: retrievers[retrId]?.display_name ?? retrId,
       paradigm: retrievers[retrId]?.paradigm ?? retr.paradigm ?? "",
@@ -246,6 +248,7 @@ function buildPerDatasetViews(
           method_id: lm.id,
           method_display: lm.display,
           model: r.model,
+          model_display: displayModel(r.model),
           retriever_id: r.retriever_id,
           retriever_display: r.retriever,
           run_id: r.run_id,            // populated/overwritten by the best cell
@@ -376,33 +379,38 @@ function buildHomeMatrix(
       method_id: lm.id,
       method_display: lm.display,
       model: r.model,
+      model_display: displayModel(r.model),
       retriever_id: r.retriever_id,
       retriever_display: r.retriever,
     }),
   );
 
-  // Dataset columns + primary/secondary metric per dataset.
-  // Primary = nDCG@10 if present, else first eval metric.
-  // Secondary = recall@1000 (DL) or recall@100 (BEIR), else null.
+  // Dataset columns: derive primary/secondary metric from what's ACTUALLY in
+  // the matrix data (not from the registry whitelist, which may over-specify).
+  // primary  = ndcg_cut_10 if present, else the first metric found.
+  // secondary = recall_1000 if present, else recall_100, else any other metric.
   const datasetCols = Object.values(datasets)
     .sort((a, b) => a.id.localeCompare(b.id))
     .map((d) => {
-      const metrics = d.eval_metrics;
+      const present = new Set<string>();
+      for (const row of matrixRows) {
+        for (const m of Object.keys(row.values?.[d.id] ?? {})) present.add(m);
+      }
+      const arr = Array.from(present);
       const primary =
-        metrics.find((m) => m === "ndcg_cut_10") ??
-        metrics[0] ??
-        null;
+        present.has("ndcg_cut_10") ? "ndcg_cut_10" : arr[0] ?? null;
       const secondary =
-        metrics.find((m) => m === "recall_1000") ??
-        metrics.find((m) => m === "recall_100") ??
-        metrics.find((m) => m !== primary) ??
-        null;
+        present.has("recall_1000")
+          ? "recall_1000"
+          : present.has("recall_100")
+            ? "recall_100"
+            : arr.find((m) => m !== primary) ?? null;
       return {
         id: d.id,
         name: d.name,
         primary_metric: primary,
         secondary_metric: secondary,
-        all_metrics: metrics,
+        all_metrics: arr.sort(),
       };
     });
 
@@ -453,6 +461,7 @@ function buildPerMethodViews(rows: ResultRow[]) {
       (r) => `${r.model}|${r.retriever_id}`,
       (r) => ({
         model: r.model,
+        model_display: displayModel(r.model),
         retriever_id: r.retriever_id,
         retriever_display: r.retriever,
       }),
@@ -479,6 +488,7 @@ function buildPerRetrieverViews(rows: ResultRow[]) {
         method_id: lm.id,
         method_display: lm.display,
         model: r.model,
+        model_display: displayModel(r.model),
       }),
     );
     writeJSON(path.join(VIEWS_DIR, `retriever-${retriever_id}.json`), {
@@ -491,6 +501,13 @@ function buildPerRetrieverViews(rows: ResultRow[]) {
 // Some model ids contain "/" (e.g. "openai/gpt-4.1"); URL-encode for file paths.
 function encodePathSegment(s: string): string {
   return s.replace(/\//g, "__");
+}
+
+// Strip provider prefix from a model id for display: "openai/gpt-4.1" → "gpt-4.1".
+// The canonical id stays in the data; this is purely cosmetic.
+function displayModel(s: string): string {
+  const i = s.indexOf("/");
+  return i >= 0 ? s.slice(i + 1) : s;
 }
 
 // ---------- main ------------------------------------------------------------
@@ -556,7 +573,12 @@ function main() {
   writeJSON(path.join(OUT_DIR, "methods.json"), methodList);
 
   const modelList = Array.from(modelCounts.entries())
-    .map(([id, run_count]) => ({ id, run_count, slug: encodePathSegment(id) }))
+    .map(([id, run_count]) => ({
+      id,
+      display: displayModel(id),
+      run_count,
+      slug: encodePathSegment(id),
+    }))
     .sort((a, b) => a.id.localeCompare(b.id));
   writeJSON(path.join(OUT_DIR, "models.json"), modelList);
 

--- a/reproducibility/site/src/components/InteractiveTable.astro
+++ b/reproducibility/site/src/components/InteractiveTable.astro
@@ -1,0 +1,171 @@
+---
+/**
+ * Wraps a server-rendered <table> with a global search input + click-to-sort
+ * column headers. Vanilla JS — no framework island.
+ *
+ * Conventions inside the wrapped table:
+ *   - Every <th> in <thead> is sortable. Add data-sort-skip on a <th> to skip it.
+ *   - Each <td> can have data-sort-value="<number-or-string>" to override the
+ *     visible text for sorting (useful for cells containing links or formatted
+ *     numbers). When absent, the cell's textContent is used.
+ *   - Each <tr> in <tbody> is searched against the input by concatenated
+ *     textContent (case-insensitive).
+ */
+
+interface Props {
+  /** Search placeholder text. */
+  searchPlaceholder?: string;
+  /** Initial sort: { columnIndex, direction } */
+  initialSort?: { column: number; direction: "asc" | "desc" };
+}
+
+const { searchPlaceholder = "Search rows…", initialSort } = Astro.props;
+const initialSortAttr = initialSort
+  ? `${initialSort.column}:${initialSort.direction}`
+  : "";
+---
+
+<div class="qg-itable" data-initial-sort={initialSortAttr}>
+  <div class="mb-3 flex flex-wrap items-center gap-3 text-sm">
+    <input
+      type="search"
+      class="qg-itable-search w-64 rounded border border-qg-border bg-qg-bg-soft px-3 py-1.5 text-sm focus:border-qg-accent focus:outline-none"
+      placeholder={searchPlaceholder}
+      autocomplete="off"
+    />
+    <span class="text-qg-fg-muted">
+      <span class="qg-itable-shown">0</span> / <span class="qg-itable-total">0</span> rows
+    </span>
+  </div>
+  <slot />
+</div>
+
+<style is:global>
+  .qg-itable table thead th {
+    cursor: pointer;
+    user-select: none;
+  }
+  .qg-itable table thead th[data-sort-skip] {
+    cursor: default;
+  }
+  .qg-itable table thead th .qg-sort-arrow {
+    opacity: 0.35;
+    margin-left: 0.25rem;
+    font-size: 0.7rem;
+  }
+  .qg-itable table thead th[data-sort-dir="asc"] .qg-sort-arrow,
+  .qg-itable table thead th[data-sort-dir="desc"] .qg-sort-arrow {
+    opacity: 1;
+    color: var(--qg-accent);
+  }
+</style>
+
+<script>
+  function wireInteractiveTable(root: HTMLElement) {
+    if (root.dataset.qgWired === "1") return;
+    root.dataset.qgWired = "1";
+
+    const table = root.querySelector("table");
+    if (!table) return;
+    const tbody = table.querySelector("tbody");
+    if (!tbody) return;
+    const headers = Array.from(table.querySelectorAll("thead th"));
+    const allRows = Array.from(tbody.querySelectorAll<HTMLTableRowElement>("tr"));
+    const shownCounter = root.querySelector(".qg-itable-shown");
+    const totalCounter = root.querySelector(".qg-itable-total");
+    const search = root.querySelector<HTMLInputElement>(".qg-itable-search");
+
+    if (totalCounter) totalCounter.textContent = String(allRows.length);
+
+    // Pre-cache sortable values + searchable text per row.
+    const meta = allRows.map((tr) => ({
+      tr,
+      searchText: tr.textContent?.toLowerCase() ?? "",
+      cells: Array.from(tr.cells).map((c) => {
+        const raw = c.dataset.sortValue ?? c.textContent ?? "";
+        const num = parseFloat(raw);
+        return { raw, num: Number.isFinite(num) ? num : null };
+      }),
+    }));
+
+    let currentSort: { column: number; direction: "asc" | "desc" } | null = null;
+
+    function addArrows() {
+      headers.forEach((th) => {
+        if (th.querySelector(".qg-sort-arrow")) return;
+        if ((th as HTMLElement).dataset.sortSkip !== undefined) return;
+        const span = document.createElement("span");
+        span.className = "qg-sort-arrow";
+        span.textContent = "↕";
+        th.appendChild(span);
+      });
+    }
+
+    function setSort(colIdx: number, dir: "asc" | "desc") {
+      currentSort = { column: colIdx, direction: dir };
+      headers.forEach((th, i) => {
+        const arrow = th.querySelector<HTMLElement>(".qg-sort-arrow");
+        if (i === colIdx) {
+          (th as HTMLElement).dataset.sortDir = dir;
+          if (arrow) arrow.textContent = dir === "asc" ? "↑" : "↓";
+        } else {
+          delete (th as HTMLElement).dataset.sortDir;
+          if (arrow) arrow.textContent = "↕";
+        }
+      });
+      const sorted = [...meta].sort((a, b) => {
+        const av = a.cells[colIdx];
+        const bv = b.cells[colIdx];
+        if (av?.num !== null && bv?.num !== null) {
+          return dir === "asc" ? av.num! - bv.num! : bv.num! - av.num!;
+        }
+        return dir === "asc"
+          ? (av?.raw ?? "").localeCompare(bv?.raw ?? "")
+          : (bv?.raw ?? "").localeCompare(av?.raw ?? "");
+      });
+      const frag = document.createDocumentFragment();
+      sorted.forEach((m) => frag.appendChild(m.tr));
+      tbody.appendChild(frag);
+    }
+
+    function applySearch() {
+      const q = (search?.value ?? "").trim().toLowerCase();
+      let shown = 0;
+      for (const m of meta) {
+        // Rows hidden by an external filter (e.g. the home page's chip
+        // selection) carry .qg-chip-hidden — respect that as a hard veto.
+        const chipHidden = m.tr.classList.contains("qg-chip-hidden");
+        const matchesSearch = !q || m.searchText.includes(q);
+        const ok = matchesSearch && !chipHidden;
+        m.tr.style.display = ok ? "" : "none";
+        if (ok) shown++;
+      }
+      if (shownCounter) shownCounter.textContent = String(shown);
+    }
+
+    addArrows();
+    headers.forEach((th, i) => {
+      if ((th as HTMLElement).dataset.sortSkip !== undefined) return;
+      th.addEventListener("click", () => {
+        const nextDir =
+          currentSort?.column === i && currentSort.direction === "asc" ? "desc" : "asc";
+        setSort(i, nextDir);
+      });
+    });
+    search?.addEventListener("input", applySearch);
+    // External code can fire this event after toggling .qg-chip-hidden on
+    // rows to re-sync row visibility + the shown-count badge.
+    root.addEventListener("qg-itable-reapply", () => applySearch());
+
+    // Initial state.
+    applySearch();
+    const initial = root.dataset.initialSort;
+    if (initial) {
+      const [colStr, dir] = initial.split(":");
+      const col = parseInt(colStr, 10);
+      if (!Number.isNaN(col)) setSort(col, (dir as "asc" | "desc") ?? "asc");
+    }
+  }
+
+  document.querySelectorAll<HTMLElement>(".qg-itable").forEach(wireInteractiveTable);
+</script>

--- a/reproducibility/site/src/pages/datasets/[id].astro
+++ b/reproducibility/site/src/pages/datasets/[id].astro
@@ -2,6 +2,7 @@
 import Default from "../../layouts/Default.astro";
 import EmptyState from "../../components/EmptyState.astro";
 import MetricCell from "../../components/MetricCell.astro";
+import InteractiveTable from "../../components/InteractiveTable.astro";
 import datasetsList from "../../data/datasets.json";
 
 // Eagerly load all per-dataset shards. Astro statically analyzes this so it
@@ -47,42 +48,46 @@ const metricCols: string[] = view?.metric_columns ?? datasetMeta?.eval_metrics ?
         />
       </div>
     ) : (
-      <div class="mt-6 overflow-x-auto">
-        <table class="w-full border-collapse text-sm">
-          <thead>
-            <tr class="border-b border-qg-border text-left">
-              <th class="px-3 py-2">Method</th>
-              <th class="px-3 py-2">Model</th>
-              <th class="px-3 py-2">Retriever</th>
-              {metricCols.map((m) => (
-                <th class="px-3 py-2 text-right qg-mono text-xs">{m}</th>
-              ))}
-              <th class="px-3 py-2 text-right">Run</th>
-            </tr>
-          </thead>
-          <tbody>
-            {runs.map((r: any) => (
-              <tr class="border-b border-qg-border/60 hover:bg-qg-bg-soft">
-                <td class="px-3 py-2 font-medium">{r.method_display ?? r.method_id}</td>
-                <td class="px-3 py-2 qg-mono text-xs">{r.model}</td>
-                <td class="px-3 py-2 text-xs">{r.retriever_display ?? r.retriever_id}</td>
-                {metricCols.map((m) => (
-                  <td class="px-3 py-2 text-right">
-                    <MetricCell value={r.metrics?.[m]} best={r.best_for?.[m]} />
-                  </td>
+      <div class="mt-6">
+        <InteractiveTable searchPlaceholder="Filter by method, model, retriever…">
+          <div class="overflow-x-auto">
+            <table class="w-full border-collapse text-sm">
+              <thead>
+                <tr class="border-b border-qg-border text-left">
+                  <th class="px-3 py-2">Method</th>
+                  <th class="px-3 py-2">Model</th>
+                  <th class="px-3 py-2">Retriever</th>
+                  {metricCols.map((m) => (
+                    <th class="px-3 py-2 text-right qg-mono text-xs">{m}</th>
+                  ))}
+                  <th class="px-3 py-2 text-right" data-sort-skip>Run</th>
+                </tr>
+              </thead>
+              <tbody>
+                {runs.map((r: any) => (
+                  <tr class="border-b border-qg-border/60 hover:bg-qg-bg-soft">
+                    <td class="px-3 py-2 font-medium">{r.method_display ?? r.method_id}</td>
+                    <td class="px-3 py-2 qg-mono text-xs" data-sort-value={r.model_display ?? r.model}>{r.model_display ?? r.model}</td>
+                    <td class="px-3 py-2 text-xs">{r.retriever_display ?? r.retriever_id}</td>
+                    {metricCols.map((m) => (
+                      <td class="px-3 py-2 text-right" data-sort-value={r.metrics?.[m] ?? ""}>
+                        <MetricCell value={r.metrics?.[m]} best={r.best_for?.[m]} />
+                      </td>
+                    ))}
+                    <td class="px-3 py-2 text-right">
+                      <a
+                        class="qg-mono text-xs text-qg-accent hover:underline"
+                        href={`/runs/${r.run_id}`}
+                      >
+                        {r.run_id.slice(0, 8)}…
+                      </a>
+                    </td>
+                  </tr>
                 ))}
-                <td class="px-3 py-2 text-right">
-                  <a
-                    class="qg-mono text-xs text-qg-accent hover:underline"
-                    href={`/runs/${r.run_id}`}
-                  >
-                    {r.run_id.slice(0, 8)}…
-                  </a>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+              </tbody>
+            </table>
+          </div>
+        </InteractiveTable>
       </div>
     )
   }

--- a/reproducibility/site/src/pages/index.astro
+++ b/reproducibility/site/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Default from "../layouts/Default.astro";
 import Stat from "../components/Stat.astro";
+import InteractiveTable from "../components/InteractiveTable.astro";
 import overview from "../data/overview.json";
 import matrix from "../data/matrix.json";
 import retrievers from "../data/retrievers.json";
@@ -72,7 +73,7 @@ const datasetCols = matrix.dataset_columns;
           <div id="qg-filter-model" class="flex flex-wrap gap-1.5">
             <button data-value="" class="qg-chip qg-chip-active">All</button>
             {models.map((m: any) => (
-              <button data-value={m.id} class="qg-chip">{m.id}</button>
+              <button data-value={m.id} class="qg-chip">{m.display ?? m.id}</button>
             ))}
           </div>
           <span class="ml-4 text-qg-fg-muted">Metric:</span>
@@ -87,70 +88,73 @@ const datasetCols = matrix.dataset_columns;
 
   {
     populated ? (
-      <section class="overflow-x-auto rounded border border-qg-border">
-        <table id="qg-matrix" class="w-full text-sm">
-          <thead class="bg-qg-bg-soft text-xs uppercase tracking-wide text-qg-fg-muted">
-            <tr>
-              <th class="px-3 py-2 text-left">Method</th>
-              <th class="px-3 py-2 text-left">Model</th>
-              <th class="px-3 py-2 text-left">Retriever</th>
-              {datasetCols.map((d: any) => (
-                <th
-                  class="qg-mono px-3 py-2 text-right text-xs"
-                  title={d.id}
-                >
-                  <span class="qg-col-label-primary">
-                    {SHORT[d.id] ?? d.name}
-                    <span class="text-qg-fg-muted"> / {METRIC_LABEL[d.primary_metric] ?? d.primary_metric}</span>
-                  </span>
-                  <span class="qg-col-label-secondary hidden">
-                    {SHORT[d.id] ?? d.name}
-                    <span class="text-qg-fg-muted"> / {METRIC_LABEL[d.secondary_metric] ?? d.secondary_metric}</span>
-                  </span>
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((row: any) => (
-              <tr
-                class="border-t border-qg-border/60 hover:bg-qg-bg-soft qg-matrix-row"
-                data-method={row.method_id}
-                data-model={row.model}
-                data-retriever={row.retriever_id}
-              >
-                <td class="px-3 py-2 font-medium">{row.method_display ?? row.method_id}</td>
-                <td class="px-3 py-2 qg-mono text-xs">{row.model}</td>
-                <td class="px-3 py-2 text-xs">{row.retriever_display ?? row.retriever_id}</td>
-                {datasetCols.map((d: any) => {
-                  const cell = row.values?.[d.id] ?? {};
-                  const runId = row.run_ids?.[d.id];
-                  const primary = cell[d.primary_metric];
-                  const secondary = d.secondary_metric ? cell[d.secondary_metric] : null;
-                  return (
-                    <td class="qg-mono px-3 py-2 text-right tabular-nums">
-                      {runId ? (
-                        <a class="hover:text-qg-accent hover:underline" href={`/runs/${runId}`} title="View run + reproduce">
-                          <span class={`qg-cell-primary ${primary?.best ? "font-bold text-qg-accent" : ""}`}>
-                            {primary !== undefined ? primary.value.toFixed(3) : "—"}
-                          </span>
-                          {secondary && (
-                            <span class={`qg-cell-secondary hidden ${secondary.best ? "font-bold text-qg-accent" : ""}`}>
-                              {secondary.value.toFixed(3)}
-                            </span>
-                          )}
-                        </a>
-                      ) : (
-                        <span class="text-qg-fg-muted">—</span>
-                      )}
-                    </td>
-                  );
-                })}
+      <InteractiveTable searchPlaceholder="Filter by method, model, retriever…">
+        <div class="overflow-x-auto rounded border border-qg-border">
+          <table id="qg-matrix" class="w-full text-sm">
+            <thead class="bg-qg-bg-soft text-xs uppercase tracking-wide text-qg-fg-muted">
+              <tr>
+                <th class="px-3 py-2 text-left">Method</th>
+                <th class="px-3 py-2 text-left">Model</th>
+                <th class="px-3 py-2 text-left">Retriever</th>
+                {datasetCols.map((d: any) => (
+                  <th
+                    class="qg-mono px-3 py-2 text-right text-xs"
+                    title={d.id}
+                  >
+                    <span class="qg-col-label-primary">
+                      {SHORT[d.id] ?? d.name}
+                      <span class="text-qg-fg-muted"> / {METRIC_LABEL[d.primary_metric] ?? d.primary_metric}</span>
+                    </span>
+                    <span class="qg-col-label-secondary hidden">
+                      {SHORT[d.id] ?? d.name}
+                      <span class="text-qg-fg-muted"> / {METRIC_LABEL[d.secondary_metric] ?? d.secondary_metric}</span>
+                    </span>
+                  </th>
+                ))}
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </section>
+            </thead>
+            <tbody>
+              {rows.map((row: any) => (
+                <tr
+                  class="border-t border-qg-border/60 hover:bg-qg-bg-soft qg-matrix-row"
+                  data-method={row.method_id}
+                  data-model={row.model}
+                  data-retriever={row.retriever_id}
+                >
+                  <td class="px-3 py-2 font-medium">{row.method_display ?? row.method_id}</td>
+                  <td class="px-3 py-2 qg-mono text-xs" data-sort-value={row.model_display ?? row.model}>{row.model_display ?? row.model}</td>
+                  <td class="px-3 py-2 text-xs">{row.retriever_display ?? row.retriever_id}</td>
+                  {datasetCols.map((d: any) => {
+                    const cell = row.values?.[d.id] ?? {};
+                    const runId = row.run_ids?.[d.id];
+                    const primary = cell[d.primary_metric];
+                    const secondary = d.secondary_metric ? cell[d.secondary_metric] : null;
+                    const primaryValue = primary?.value ?? "";
+                    return (
+                      <td class="qg-mono px-3 py-2 text-right tabular-nums" data-sort-value={primaryValue} data-primary-value={primaryValue} data-secondary-value={secondary?.value ?? ""}>
+                        {runId ? (
+                          <a class="hover:text-qg-accent hover:underline" href={`/runs/${runId}`} title="View run + reproduce">
+                            <span class={`qg-cell-primary ${primary?.best ? "font-bold text-qg-accent" : ""}`}>
+                              {primary !== undefined ? primary.value.toFixed(3) : "—"}
+                            </span>
+                            {secondary && (
+                              <span class={`qg-cell-secondary hidden ${secondary.best ? "font-bold text-qg-accent" : ""}`}>
+                                {secondary.value.toFixed(3)}
+                              </span>
+                            )}
+                          </a>
+                        ) : (
+                          <span class="text-qg-fg-muted">—</span>
+                        )}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </InteractiveTable>
     ) : (
       <div class="mt-8 rounded-lg border border-qg-border bg-qg-bg-soft p-6 text-qg-fg-muted">
         No runs yet. The matrix will populate when results land.
@@ -170,20 +174,32 @@ const datasetCols = matrix.dataset_columns;
 
 <script>
   const tbody = document.querySelector<HTMLTableSectionElement>("#qg-matrix tbody");
-  if (tbody) {
+  const itableRoot = document.querySelector<HTMLElement>("#qg-matrix")?.closest(".qg-itable") as HTMLElement | null;
+  if (tbody && itableRoot) {
     const filters = { retriever: "", model: "", metric: "primary" };
 
-    function applyFilters() {
+    function applyChipFilters() {
       tbody.querySelectorAll<HTMLTableRowElement>(".qg-matrix-row").forEach((tr) => {
         const okR = !filters.retriever || tr.dataset.retriever === filters.retriever;
         const okM = !filters.model || tr.dataset.model === filters.model;
-        tr.style.display = okR && okM ? "" : "none";
+        tr.classList.toggle("qg-chip-hidden", !(okR && okM));
       });
+      // Let InteractiveTable re-sync visibility + shown-count vs its own search input.
+      itableRoot!.dispatchEvent(new CustomEvent("qg-itable-reapply"));
+    }
+
+    function applyMetricMode() {
       const primaryShown = filters.metric === "primary";
       document.querySelectorAll(".qg-col-label-primary").forEach((el) => el.classList.toggle("hidden", !primaryShown));
       document.querySelectorAll(".qg-col-label-secondary").forEach((el) => el.classList.toggle("hidden", primaryShown));
       document.querySelectorAll(".qg-cell-primary").forEach((el) => el.classList.toggle("hidden", !primaryShown));
       document.querySelectorAll(".qg-cell-secondary").forEach((el) => el.classList.toggle("hidden", primaryShown));
+      // Update each metric cell's sort key to the now-visible metric, so a
+      // subsequent column-header click sorts by what the user is looking at.
+      tbody.querySelectorAll<HTMLTableCellElement>("td[data-primary-value]").forEach((td) => {
+        const v = primaryShown ? td.dataset.primaryValue : td.dataset.secondaryValue;
+        td.dataset.sortValue = v ?? "";
+      });
     }
 
     function wireGroup(groupId: string, key: "retriever" | "model" | "metric") {
@@ -194,7 +210,8 @@ const datasetCols = matrix.dataset_columns;
           group.querySelectorAll("button").forEach((b) => b.classList.remove("qg-chip-active"));
           btn.classList.add("qg-chip-active");
           filters[key] = btn.dataset.value ?? "";
-          applyFilters();
+          if (key === "metric") applyMetricMode();
+          else applyChipFilters();
         });
       });
     }

--- a/reproducibility/site/src/pages/methods/[id].astro
+++ b/reproducibility/site/src/pages/methods/[id].astro
@@ -1,6 +1,7 @@
 ---
 import Default from "../../layouts/Default.astro";
 import EmptyState from "../../components/EmptyState.astro";
+import InteractiveTable from "../../components/InteractiveTable.astro";
 import methods from "../../data/methods.json";
 
 const shards = import.meta.glob<{ default: any }>(
@@ -54,47 +55,52 @@ const title = view?.method_display ?? meta?.display ?? id ?? "Method";
         <EmptyState title="No runs for this method yet" body="" />
       </div>
     ) : (
-      <section class="mt-6 overflow-x-auto rounded border border-qg-border">
-        <table class="w-full text-sm">
-          <thead class="bg-qg-bg-soft text-xs uppercase tracking-wide text-qg-fg-muted">
-            <tr>
-              <th class="px-3 py-2 text-left">Model</th>
-              <th class="px-3 py-2 text-left">Retriever</th>
-              {datasetCols.map((d: any) => (
-                <th class="qg-mono px-3 py-2 text-right text-xs" title={d.id}>
-                  {SHORT[d.id] ?? d.name}
-                  <span class="text-qg-fg-muted"> / {METRIC_LABEL[d.primary_metric] ?? d.primary_metric}</span>
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((row: any) => (
-              <tr class="border-t border-qg-border/60 hover:bg-qg-bg-soft">
-                <td class="px-3 py-2 qg-mono text-xs">{row.model}</td>
-                <td class="px-3 py-2 text-xs">{row.retriever_display ?? row.retriever_id}</td>
-                {datasetCols.map((d: any) => {
-                  const cell = row.values?.[d.id] ?? {};
-                  const runId = row.run_ids?.[d.id];
-                  const primary = cell[d.primary_metric];
-                  return (
-                    <td class="qg-mono px-3 py-2 text-right tabular-nums">
-                      {runId && primary !== undefined ? (
-                        <a class="hover:text-qg-accent hover:underline" href={`/runs/${runId}`}>
-                          <span class={primary.best ? "font-bold text-qg-accent" : ""}>
-                            {primary.value.toFixed(3)}
-                          </span>
-                        </a>
-                      ) : (
-                        <span class="text-qg-fg-muted">—</span>
-                      )}
-                    </td>
-                  );
-                })}
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      <section class="mt-6">
+        <InteractiveTable searchPlaceholder="Filter by model, retriever…">
+          <div class="overflow-x-auto rounded border border-qg-border">
+            <table class="w-full text-sm">
+              <thead class="bg-qg-bg-soft text-xs uppercase tracking-wide text-qg-fg-muted">
+                <tr>
+                  <th class="px-3 py-2 text-left">Model</th>
+                  <th class="px-3 py-2 text-left">Retriever</th>
+                  {datasetCols.map((d: any) => (
+                    <th class="qg-mono px-3 py-2 text-right text-xs" title={d.id}>
+                      {SHORT[d.id] ?? d.name}
+                      <span class="text-qg-fg-muted"> / {METRIC_LABEL[d.primary_metric] ?? d.primary_metric}</span>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row: any) => (
+                  <tr class="border-t border-qg-border/60 hover:bg-qg-bg-soft">
+                    <td class="px-3 py-2 qg-mono text-xs" data-sort-value={row.model_display ?? row.model}>{row.model_display ?? row.model}</td>
+                    <td class="px-3 py-2 text-xs">{row.retriever_display ?? row.retriever_id}</td>
+                    {datasetCols.map((d: any) => {
+                      const cell = row.values?.[d.id] ?? {};
+                      const runId = row.run_ids?.[d.id];
+                      const primary = cell[d.primary_metric];
+                      const v = primary?.value ?? "";
+                      return (
+                        <td class="qg-mono px-3 py-2 text-right tabular-nums" data-sort-value={v}>
+                          {runId && primary !== undefined ? (
+                            <a class="hover:text-qg-accent hover:underline" href={`/runs/${runId}`}>
+                              <span class={primary.best ? "font-bold text-qg-accent" : ""}>
+                                {primary.value.toFixed(3)}
+                              </span>
+                            </a>
+                          ) : (
+                            <span class="text-qg-fg-muted">—</span>
+                          )}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </InteractiveTable>
       </section>
     )
   }

--- a/reproducibility/site/src/pages/models/[id].astro
+++ b/reproducibility/site/src/pages/models/[id].astro
@@ -1,6 +1,7 @@
 ---
 import Default from "../../layouts/Default.astro";
 import EmptyState from "../../components/EmptyState.astro";
+import InteractiveTable from "../../components/InteractiveTable.astro";
 import models from "../../data/models.json";
 
 const shards = import.meta.glob<{ default: any }>(
@@ -41,7 +42,7 @@ const METRIC_LABEL: Record<string, string> = {
 // Dataset columns from the shared home matrix shape (re-derive from rows).
 const datasetCols = (await import("../../data/matrix.json")).default.dataset_columns;
 
-const title = view?.model ?? id ?? "Model";
+const title = meta?.display ?? view?.model ?? id ?? "Model";
 ---
 
 <Default title={title} description={`Per-LLM leaderboard for ${title}.`}>
@@ -55,47 +56,52 @@ const title = view?.model ?? id ?? "Model";
         <EmptyState title="No runs for this model yet" body="" />
       </div>
     ) : (
-      <section class="mt-6 overflow-x-auto rounded border border-qg-border">
-        <table class="w-full text-sm">
-          <thead class="bg-qg-bg-soft text-xs uppercase tracking-wide text-qg-fg-muted">
-            <tr>
-              <th class="px-3 py-2 text-left">Method</th>
-              <th class="px-3 py-2 text-left">Retriever</th>
-              {datasetCols.map((d: any) => (
-                <th class="qg-mono px-3 py-2 text-right text-xs" title={d.id}>
-                  {SHORT[d.id] ?? d.name}
-                  <span class="text-qg-fg-muted"> / {METRIC_LABEL[d.primary_metric] ?? d.primary_metric}</span>
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((row: any) => (
-              <tr class="border-t border-qg-border/60 hover:bg-qg-bg-soft">
-                <td class="px-3 py-2 font-medium">{row.method_display ?? row.method_id}</td>
-                <td class="px-3 py-2 text-xs">{row.retriever_display ?? row.retriever_id}</td>
-                {datasetCols.map((d: any) => {
-                  const cell = row.values?.[d.id] ?? {};
-                  const runId = row.run_ids?.[d.id];
-                  const primary = cell[d.primary_metric];
-                  return (
-                    <td class="qg-mono px-3 py-2 text-right tabular-nums">
-                      {runId && primary !== undefined ? (
-                        <a class="hover:text-qg-accent hover:underline" href={`/runs/${runId}`}>
-                          <span class={primary.best ? "font-bold text-qg-accent" : ""}>
-                            {primary.value.toFixed(3)}
-                          </span>
-                        </a>
-                      ) : (
-                        <span class="text-qg-fg-muted">—</span>
-                      )}
-                    </td>
-                  );
-                })}
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      <section class="mt-6">
+        <InteractiveTable searchPlaceholder="Filter by method, retriever…">
+          <div class="overflow-x-auto rounded border border-qg-border">
+            <table class="w-full text-sm">
+              <thead class="bg-qg-bg-soft text-xs uppercase tracking-wide text-qg-fg-muted">
+                <tr>
+                  <th class="px-3 py-2 text-left">Method</th>
+                  <th class="px-3 py-2 text-left">Retriever</th>
+                  {datasetCols.map((d: any) => (
+                    <th class="qg-mono px-3 py-2 text-right text-xs" title={d.id}>
+                      {SHORT[d.id] ?? d.name}
+                      <span class="text-qg-fg-muted"> / {METRIC_LABEL[d.primary_metric] ?? d.primary_metric}</span>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row: any) => (
+                  <tr class="border-t border-qg-border/60 hover:bg-qg-bg-soft">
+                    <td class="px-3 py-2 font-medium">{row.method_display ?? row.method_id}</td>
+                    <td class="px-3 py-2 text-xs">{row.retriever_display ?? row.retriever_id}</td>
+                    {datasetCols.map((d: any) => {
+                      const cell = row.values?.[d.id] ?? {};
+                      const runId = row.run_ids?.[d.id];
+                      const primary = cell[d.primary_metric];
+                      const v = primary?.value ?? "";
+                      return (
+                        <td class="qg-mono px-3 py-2 text-right tabular-nums" data-sort-value={v}>
+                          {runId && primary !== undefined ? (
+                            <a class="hover:text-qg-accent hover:underline" href={`/runs/${runId}`}>
+                              <span class={primary.best ? "font-bold text-qg-accent" : ""}>
+                                {primary.value.toFixed(3)}
+                              </span>
+                            </a>
+                          ) : (
+                            <span class="text-qg-fg-muted">—</span>
+                          )}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </InteractiveTable>
       </section>
     )
   }

--- a/reproducibility/site/src/pages/retrievers/[id].astro
+++ b/reproducibility/site/src/pages/retrievers/[id].astro
@@ -1,6 +1,7 @@
 ---
 import Default from "../../layouts/Default.astro";
 import EmptyState from "../../components/EmptyState.astro";
+import InteractiveTable from "../../components/InteractiveTable.astro";
 import retrievers from "../../data/retrievers.json";
 
 const shards = import.meta.glob<{ default: any }>(
@@ -53,47 +54,52 @@ const title = meta?.display_name ?? id ?? "Retriever";
         <EmptyState title="No runs for this retriever yet" body="" />
       </div>
     ) : (
-      <section class="mt-6 overflow-x-auto rounded border border-qg-border">
-        <table class="w-full text-sm">
-          <thead class="bg-qg-bg-soft text-xs uppercase tracking-wide text-qg-fg-muted">
-            <tr>
-              <th class="px-3 py-2 text-left">Method</th>
-              <th class="px-3 py-2 text-left">Model</th>
-              {datasetCols.map((d: any) => (
-                <th class="qg-mono px-3 py-2 text-right text-xs" title={d.id}>
-                  {SHORT[d.id] ?? d.name}
-                  <span class="text-qg-fg-muted"> / {METRIC_LABEL[d.primary_metric] ?? d.primary_metric}</span>
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((row: any) => (
-              <tr class="border-t border-qg-border/60 hover:bg-qg-bg-soft">
-                <td class="px-3 py-2 font-medium">{row.method_display ?? row.method_id}</td>
-                <td class="px-3 py-2 qg-mono text-xs">{row.model}</td>
-                {datasetCols.map((d: any) => {
-                  const cell = row.values?.[d.id] ?? {};
-                  const runId = row.run_ids?.[d.id];
-                  const primary = cell[d.primary_metric];
-                  return (
-                    <td class="qg-mono px-3 py-2 text-right tabular-nums">
-                      {runId && primary !== undefined ? (
-                        <a class="hover:text-qg-accent hover:underline" href={`/runs/${runId}`}>
-                          <span class={primary.best ? "font-bold text-qg-accent" : ""}>
-                            {primary.value.toFixed(3)}
-                          </span>
-                        </a>
-                      ) : (
-                        <span class="text-qg-fg-muted">—</span>
-                      )}
-                    </td>
-                  );
-                })}
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      <section class="mt-6">
+        <InteractiveTable searchPlaceholder="Filter by method, model…">
+          <div class="overflow-x-auto rounded border border-qg-border">
+            <table class="w-full text-sm">
+              <thead class="bg-qg-bg-soft text-xs uppercase tracking-wide text-qg-fg-muted">
+                <tr>
+                  <th class="px-3 py-2 text-left">Method</th>
+                  <th class="px-3 py-2 text-left">Model</th>
+                  {datasetCols.map((d: any) => (
+                    <th class="qg-mono px-3 py-2 text-right text-xs" title={d.id}>
+                      {SHORT[d.id] ?? d.name}
+                      <span class="text-qg-fg-muted"> / {METRIC_LABEL[d.primary_metric] ?? d.primary_metric}</span>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row: any) => (
+                  <tr class="border-t border-qg-border/60 hover:bg-qg-bg-soft">
+                    <td class="px-3 py-2 font-medium">{row.method_display ?? row.method_id}</td>
+                    <td class="px-3 py-2 qg-mono text-xs" data-sort-value={row.model_display ?? row.model}>{row.model_display ?? row.model}</td>
+                    {datasetCols.map((d: any) => {
+                      const cell = row.values?.[d.id] ?? {};
+                      const runId = row.run_ids?.[d.id];
+                      const primary = cell[d.primary_metric];
+                      const v = primary?.value ?? "";
+                      return (
+                        <td class="qg-mono px-3 py-2 text-right tabular-nums" data-sort-value={v}>
+                          {runId && primary !== undefined ? (
+                            <a class="hover:text-qg-accent hover:underline" href={`/runs/${runId}`}>
+                              <span class={primary.best ? "font-bold text-qg-accent" : ""}>
+                                {primary.value.toFixed(3)}
+                              </span>
+                            </a>
+                          ) : (
+                            <span class="text-qg-fg-muted">—</span>
+                          )}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </InteractiveTable>
       </section>
     )
   }

--- a/reproducibility/site/src/pages/runs/[run_id].astro
+++ b/reproducibility/site/src/pages/runs/[run_id].astro
@@ -101,7 +101,7 @@ const trecEvalCmd = `python -m pyserini.eval.trec_eval -c -m ${run.metrics ? Obj
   <section class="mt-6 grid gap-4 md:grid-cols-3">
     <Field label="Dataset" value={run.dataset_id} />
     <Field label="Method" value={run.method_id} />
-    <Field label="Model" value={run.model} />
+    <Field label="Model" value={run.model_display ?? run.model} />
     <Field label="Retriever" value={`${run.retriever_display ?? run.retriever_id ?? "—"} (${run.paradigm ?? "?"})`} />
     <Field label="params_hash" value={run.params_hash} />
     <Field label="Queries" value={run.num_queries} />


### PR DESCRIPTION
## Summary

Three follow-ups on the redesigned leaderboard (PR #26).

**1. Short model labels.** Display strips the provider prefix everywhere it shows: `openai/gpt-4.1` → `gpt-4.1`, `Qwen/Qwen2.5-7B-Instruct` → `Qwen2.5-7B-Instruct`. The canonical id stays in the data (run paths, hashes, registry); only the visual presentation changes. New `model_display` field on matrix rows, per-X view rows, `runs.json`, `models.json`.

**2. Recall toggle works on BEIR.** On the home matrix, toggling to recall now shows real values for every column. The secondary metric for each dataset is now derived from what's actually present in the matrix data (`recall_1000` for DL/DL-HARD, `recall_100` for BEIR) instead of being driven by the registry whitelist. Fixes labels like "ArguAna / R@1k" — now correctly `ArguAna / R@100`.

**3. Sortable + searchable tables.** New `InteractiveTable.astro` component wraps every matrix table with a global search input and click-to-sort column headers. Numeric columns carry `data-sort-value` so `0.6952` sorts numerically. Applied to home + `/datasets/{id}` + `/models/{id}` + `/methods/{id}` + `/retrievers/{id}`.

The home page's existing retriever/model/metric filter chips coexist with the InteractiveTable via a class-and-event handshake: chips set `qg-chip-hidden` on rows and dispatch `qg-itable-reapply`, the table script respects that as a hard veto over its own search.

## Test Plan
- [x] `pnpm -F @qg/leaderboard build` — clean, 1113 pages.
- [x] After merge: CF Pages auto-deploys; verify (a) model column shows just `gpt-4.1` / `Qwen2.5-72B-Instruct`, (b) toggling to Recall on the home matrix populates BEIR columns, (c) every matrix table has a search box + clickable sort headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)