### PR TITLE
reproducibility: normalize absolute paths at emit, reject them in validation

### DIFF
--- a/reproducibility/lib/emit.py
+++ b/reproducibility/lib/emit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import platform as _platform
+import re
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -16,6 +17,41 @@ SCHEMA_VERSION = 1
 def _stable_json(payload: Any) -> str:
     """Serialize with sorted keys and no whitespace — deterministic across runs."""
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+_ABS_PATH_RE = re.compile(r"^(?:/|[A-Za-z]:[\\/])")
+
+
+def _is_abs_path(value: Any) -> bool:
+    """True if `value` is a string that looks like a machine-specific absolute
+    filesystem path (POSIX '/...' or Windows 'C:\\...'). Registry keys and
+    relative paths are not absolute."""
+    return isinstance(value, str) and bool(_ABS_PATH_RE.match(value))
+
+
+def _portable_path(value: Any) -> Any:
+    """Collapse a machine-specific absolute path to a portable 'parent/name'
+    form so a run's identity is host-independent.
+
+        '/mnt/data/son/data/msmarco/collection.tsv' -> 'msmarco/collection.tsv'
+
+    Non-absolute strings (registry keys like 'dl19-passage', already-relative
+    paths) and non-strings pass through unchanged. Idempotent — applying it to
+    an already-portable value is a no-op.
+    """
+    if not _is_abs_path(value):
+        return value
+    parts = [p for p in re.split(r"[\\/]+", value) if p and p not in (".", "..")]
+    if parts and re.fullmatch(r"[A-Za-z]:", parts[0]):
+        parts = parts[1:]  # drop a Windows drive letter ('C:')
+    if not parts:
+        return value
+    return "/".join(parts[-2:])
+
+
+def _portabilize(mapping: Mapping[str, Any]) -> dict:
+    """Copy of `mapping` with any absolute-path string values made portable."""
+    return {k: _portable_path(v) for k, v in mapping.items()}
 
 
 def compute_params_hash(
@@ -143,6 +179,11 @@ def build_run_summary(
     writing — that adds runtime checks against the dataset/method/retriever
     registries.
     """
+    # Strip machine-specific absolute paths so the run identity is host-
+    # independent (e.g. a few-shot collection_path or a custom topics file).
+    # Done before hashing so params_hash is computed over the portable values.
+    method_params = _portabilize(method_params)
+
     params_hash = compute_params_hash(method_id, model, method_params, llm_config)
 
     retrieval_block: dict = {
@@ -172,8 +213,8 @@ def build_run_summary(
             "method_params": dict(method_params),
             "llm_config": dict(llm_config),
             "dataset_config": {
-                "topics": dataset_config["topics"],
-                "index": dataset_config["index"],
+                "topics": _portable_path(dataset_config["topics"]),
+                "index": _portable_path(dataset_config["index"]),
                 "num_queries": int(dataset_config["num_queries"]),
             },
             "retrieval": retrieval_block,

--- a/reproducibility/lib/validate.py
+++ b/reproducibility/lib/validate.py
@@ -7,7 +7,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 
-from .emit import compute_params_hash, compute_run_id
+from .emit import compute_params_hash, compute_run_id, _is_abs_path
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SCHEMA_PATH = Path(__file__).resolve().parent.parent / "schema.json"
@@ -98,6 +98,7 @@ def validate(
     Pass skip_registry_checks=True only in tests that intentionally use unknown ids.
     """
     _jsonschema_validate(payload)
+    _validate_no_absolute_paths(payload)
 
     if not skip_registry_checks:
         if dataset_registry is None:
@@ -168,6 +169,31 @@ def _validate_registries(
         raise ValidationError(
             f"metric(s) {sorted(unknown)} not in eval_metrics for dataset "
             f"'{dataset_id}' (allowed: {sorted(allowed)})"
+        )
+
+
+def _validate_no_absolute_paths(payload: Mapping[str, Any]) -> None:
+    """Reject machine-specific absolute paths in the config — run identities
+    must be host-independent. build_run_summary normalizes these automatically;
+    this guard catches summaries produced by other (or hand-rolled) emitters so
+    CI blocks any run that would reintroduce a host path."""
+    config = payload["config"]
+    offenders = [
+        f"method_params.{k}"
+        for k, v in config.get("method_params", {}).items()
+        if _is_abs_path(v)
+    ]
+    dataset_config = config.get("dataset_config", {})
+    offenders += [
+        f"dataset_config.{k}"
+        for k in ("topics", "index")
+        if _is_abs_path(dataset_config.get(k))
+    ]
+    if offenders:
+        raise ValidationError(
+            f"machine-specific absolute path(s) in config: {offenders}. "
+            "Use portable relative paths (build_run_summary normalizes these "
+            "automatically)."
         )
 
 

--- a/reproducibility/tests/test_repro_schema.py
+++ b/reproducibility/tests/test_repro_schema.py
@@ -601,3 +601,118 @@ def test_validator_accepts_dlhard_run():
     kw["metrics"] = {"ndcg_cut_10": 0.4038, "recall_1000": 0.8415}
     p = build_run_summary(**kw)
     validate(p)
+
+
+# ---------- Portable paths (no machine-specific absolute paths) --------------
+
+
+def test_portable_path_normalizes_absolute_paths():
+    from reproducibility.lib.emit import _portable_path
+
+    assert (
+        _portable_path("/mnt/data/son/data/msmarco/collection.tsv")
+        == "msmarco/collection.tsv"
+    )
+    assert (
+        _portable_path("/mnt/data/son/Thesis/t5/data/dlhard/neutral_queries.tsv")
+        == "dlhard/neutral_queries.tsv"
+    )
+    assert _portable_path(r"C:\Users\bob\data\msmarco\collection.tsv") == "msmarco/collection.tsv"
+
+
+def test_portable_path_leaves_identifiers_and_is_idempotent():
+    from reproducibility.lib.emit import _portable_path
+
+    # registry keys / short identifiers are not paths — untouched
+    assert _portable_path("dl19-passage") == "dl19-passage"
+    assert _portable_path("msmarco-v1-passage") == "msmarco-v1-passage"
+    assert _portable_path("beir-v1.0.0-arguana-test") == "beir-v1.0.0-arguana-test"
+    # non-strings pass through
+    assert _portable_path(4) == 4
+    # already-relative / already-normalized — idempotent
+    assert _portable_path("msmarco/collection.tsv") == "msmarco/collection.tsv"
+
+
+def test_build_run_summary_strips_absolute_method_params():
+    kw = _build_kwargs()
+    kw["method_id"] = "query2doc"
+    kw["method_params"] = {
+        "mode": "fs",
+        "collection_path": "/mnt/data/son/data/msmarco/collection.tsv",
+        "train_queries_path": "/mnt/data/son/data/msmarco/queries.train.tsv",
+    }
+    p = build_run_summary(**kw)
+    mp = p["config"]["method_params"]
+    assert mp["collection_path"] == "msmarco/collection.tsv"
+    assert mp["train_queries_path"] == "msmarco/queries.train.tsv"
+    # nothing host-specific survives anywhere in the payload
+    assert "/mnt/" not in json.dumps(p)
+
+
+def test_build_run_summary_strips_absolute_topics():
+    kw = _build_kwargs()
+    kw["dataset_id"] = "msmarco-v1-passage.dlhard"
+    kw["metrics"] = {"ndcg_cut_10": 0.4038, "recall_1000": 0.8415}
+    kw["dataset_config"] = {
+        "topics": "/mnt/data/son/Thesis/t5/data/dlhard/neutral_queries.tsv",
+        "index": "msmarco-v1-passage",
+        "num_queries": 343,
+    }
+    p = build_run_summary(**kw)
+    assert p["config"]["dataset_config"]["topics"] == "dlhard/neutral_queries.tsv"
+    assert p["config"]["dataset_config"]["index"] == "msmarco-v1-passage"
+
+
+def test_upstream_emit_reproduces_committed_legacy_hash():
+    """Normalizing an absolute few-shot path at emit time must reproduce the
+    params_hash already committed for that logical config (PR #32/#33), so a
+    fresh run of the same experiment keeps its canonical identity."""
+    h = compute_params_hash(
+        "query2doc",
+        "openai/gpt-4.1",
+        {
+            "mode": "fs",
+            "num_examples": 4,
+            "dataset_type": "msmarco",
+            "collection_path": "msmarco/collection.tsv",
+            "train_queries_path": "msmarco/queries.train.tsv",
+            "train_qrels_path": "msmarco/qrels.train.tsv",
+            "train_split": "train",
+        },
+        {"temperature": 1.0, "max_tokens": 128},
+    )
+    assert h == "97128a62"
+
+    # and building from the ABSOLUTE paths must arrive at the same hash
+    kw = _build_kwargs()
+    kw.update(
+        dataset_id="beir-v1.0.0-arguana",
+        method_id="query2doc",
+        model="openai/gpt-4.1",
+        method_params={
+            "mode": "fs",
+            "num_examples": 4,
+            "dataset_type": "msmarco",
+            "collection_path": "/mnt/data/son/data/msmarco/collection.tsv",
+            "train_queries_path": "/mnt/data/son/data/msmarco/queries.train.tsv",
+            "train_qrels_path": "/mnt/data/son/data/msmarco/qrels.train.tsv",
+            "train_split": "train",
+        },
+        llm_config={"temperature": 1.0, "max_tokens": 128},
+        metrics={"ndcg_cut_10": 0.4012, "recall_100": 0.941},
+    )
+    assert build_run_summary(**kw)["params_hash"] == "97128a62"
+
+
+def test_validator_rejects_absolute_path_in_method_params():
+    payload = _load_fixture()
+    payload["config"]["method_params"]["collection_path"] = "/mnt/data/son/data/msmarco/collection.tsv"
+    with pytest.raises(ValidationError, match="absolute path"):
+        validate(payload, skip_registry_checks=True)
+
+
+def test_validator_rejects_absolute_topics():
+    payload = _load_fixture()
+    payload["config"]["dataset_config"]["topics"] = "/abs/path/to/topics.tsv"
+    with pytest.raises(ValidationError, match="absolute path"):
+        validate(payload, skip_registry_checks=True)


### PR DESCRIPTION
## Summary

Prevents machine-specific absolute paths from entering run-summary configs, so a run's canonical identity (`params_hash`) is host-independent and future submissions can't reintroduce host paths.

Two layers:

1. **Normalize at emit** — `build_run_summary` collapses absolute-path string values in `method_params` (e.g. query2doc/query2e `collection_path`, `train_queries_path`, `train_qrels_path`) and in `dataset_config.topics` / `index` to a portable `parent/name` form, before computing `params_hash`:
   - `/mnt/data/son/data/msmarco/collection.tsv` → `msmarco/collection.tsv`
   - `…/dlhard/neutral_queries.tsv` → `dlhard/neutral_queries.tsv`

   The transform is idempotent and reproduces the relative paths already committed, so re-running a published config keeps its `params_hash`. Registry keys (`dl19-passage`, `msmarco-v1-passage`, `beir-…-test`) are not paths and are left untouched.

2. **Reject at validate** — `validate()` raises `ValidationError` on any remaining absolute path in `method_params` / `dataset_config`. Because `aggregate_runs --check` validates every run in CI, this blocks any summary — however produced — that would reintroduce a host path.

## Why here, not in the methods/loaders

The methods need the real absolute path at runtime to load the few-shot files; only the *recorded* config must be portable. `build_run_summary` is the single boundary every producer funnels through, so normalizing there covers the example pipeline, `submit_run`, and researcher runs at once. The validate guard backstops any other emitter.

## Verification

- 7 new tests; full reproducibility suite passes (51).
- A regression test reproduces a committed `params_hash` (`97128a62`) from absolute inputs, proving emit-time normalization preserves existing run identities.
- `aggregate_runs --check` unchanged — existing committed data still validates, same `content_hash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
