### PR TITLE
Redesign leaderboard with flat table, filters, and expand-panel bar c…

### DIFF
--- a/reproducibility/site/src/layouts/Default.astro
+++ b/reproducibility/site/src/layouts/Default.astro
@@ -81,6 +81,11 @@ const navLinks = [
     <link rel="icon" type="image/png" href="/querygym-logo.png" />
     <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap-index.xml" />
 
+    <!-- HuggingFace-style fonts (matching Gradio's default theme) -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
+
     {jsonLd && <script type="application/ld+json" set:html={jsonLd} />}
 
     <GoogleAnalytics />

--- a/reproducibility/site/src/pages/index.astro
+++ b/reproducibility/site/src/pages/index.astro
@@ -11,15 +11,25 @@ import { buildReproduceCmds, retrieveHint, evaluateHint, type RunLike } from "..
 const populated = overview.run_count > 0;
 
 const SHORT: Record<string, string> = {
+  // BEIR
+  "beir-v1.0.0-scifact":        "SciFact",
+  "beir-v1.0.0-arguana":        "ArguAna",
+  "beir-v1.0.0-trec-covid":     "COVID",
+  "beir-v1.0.0-fiqa":           "FiQA",
+  "beir-v1.0.0-dbpedia-entity": "DBPedia",
+  "beir-v1.0.0-trec-news":      "News",
+  // MS MARCO DL
   "msmarco-v1-passage.trecdl2019": "DL 2019",
   "msmarco-v1-passage.trecdl2020": "DL 2020",
   "msmarco-v1-passage.dlhard":     "DL-HARD",
-  "beir-v1.0.0-scifact":           "SciFact",
-  "beir-v1.0.0-arguana":           "ArguAna",
-  "beir-v1.0.0-trec-covid":        "COVID",
-  "beir-v1.0.0-fiqa":              "FiQA",
-  "beir-v1.0.0-dbpedia-entity":    "DBPedia",
-  "beir-v1.0.0-trec-news":         "News",
+  // BRIGHT
+  "bright-biology":           "Biology",
+  "bright-earth-science":     "Earth Sci.",
+  "bright-economics":         "Economics",
+  "bright-psychology":        "Psychology",
+  "bright-robotics":          "Robotics",
+  "bright-stackoverflow":     "StackOverflow",
+  "bright-sustainable-living":"Sustain. Living",
 };
 
 const METRIC_LABEL: Record<string, string> = {
@@ -29,59 +39,57 @@ const METRIC_LABEL: Record<string, string> = {
   map:         "MAP",
 };
 
-const rows = [...matrix.rows].sort((a: any, b: any) => {
+// Sort dataset columns: MS MARCO → BEIR → BRIGHT, alphabetically within each group
+function benchOrder(id: string): number {
+  if (id.startsWith("msmarco-")) return 0;
+  if (id.startsWith("beir-"))    return 1;
+  if (id.startsWith("bright-"))  return 2;
+  return 3;
+}
+const datasetCols = [...matrix.dataset_columns].sort((a: any, b: any) => {
+  const diff = benchOrder(a.id) - benchOrder(b.id);
+  return diff !== 0 ? diff : a.id.localeCompare(b.id);
+});
+// Sort matrix rows alphabetically as stable base order
+const matrixRows = [...matrix.rows].sort((a: any, b: any) => {
   if (a.method_id !== b.method_id) return a.method_id.localeCompare(b.method_id);
   if (a.model !== b.model) return a.model.localeCompare(b.model);
   return a.retriever_id.localeCompare(b.retriever_id);
 });
 
-const datasetCols = matrix.dataset_columns;
-
-const beirCols = datasetCols.filter((d: any) => d.id.startsWith("beir-"));
-const dlCols = datasetCols.filter((d: any) => !d.id.startsWith("beir-"));
-
-// JSON-LD: Dataset schema for the leaderboard itself, linked back to the
-// SoftwareApplication entry on querygym.com via sameAs. Helps Google build a
-// richer search result + connect both surfaces in the knowledge graph.
-const jsonLd = JSON.stringify({
-  "@context": "https://schema.org",
-  "@type": "Dataset",
-  name: "QueryGym Leaderboard",
-  description: "Reproducible benchmarks for LLM-based query reformulation across BEIR, MS MARCO DL, and DL-HARD — with click-to-reproduce commands for every result.",
-  url: "https://leaderboard.querygym.com/",
-  license: "https://www.apache.org/licenses/LICENSE-2.0",
-  isAccessibleForFree: true,
-  keywords: [
-    "query reformulation",
-    "large language models",
-    "information retrieval",
-    "BEIR",
-    "MS MARCO",
-    "TREC Deep Learning",
-    "reproducibility",
-    "leaderboard",
-  ],
-  creator: {
-    "@type": "Organization",
-    name: "ls3-lab",
-    url: "https://querygym.com",
-    sameAs: ["https://github.com/ls3-lab"],
+// ── Benchmark groups (computed at build time, passed to JS via define:vars) ──
+// Order: MS MARCO first, then BEIR, then BRIGHT.
+const benchmarkGroups: { key: string; label: string; datasets: { id: string; name: string }[] }[] = [
+  {
+    key: "msmarco", label: "MS MARCO",
+    datasets: datasetCols
+      .filter((d: any) => d.id.startsWith("msmarco-"))
+      .map((d: any) => ({ id: d.id, name: SHORT[d.id] ?? d.name })),
   },
-  sameAs: [
-    "https://querygym.com",
-    "https://github.com/ls3-lab/QueryGym",
-    "https://arxiv.org/abs/2511.15996",
-    "https://arxiv.org/abs/2604.27421",
-  ],
-  variableMeasured: [
-    "nDCG@10",
-    "Recall@100",
-    "Recall@1000",
-  ],
-});
+  {
+    key: "beir", label: "BEIR",
+    datasets: datasetCols
+      .filter((d: any) => d.id.startsWith("beir-"))
+      .map((d: any) => ({ id: d.id, name: SHORT[d.id] ?? d.name })),
+  },
+  {
+    key: "bright", label: "BRIGHT",
+    datasets: datasetCols
+      .filter((d: any) => d.id.startsWith("bright-"))
+      .map((d: any) => ({ id: d.id, name: SHORT[d.id] ?? d.name })),
+  },
+].filter((g) => g.datasets.length > 0);
 
-// pre-build reproduce cmds for every (row, dataset) cell that has a run.
-// Keyed by run_id so the same lookup powers all tabs.
+const DEFAULT_DATASET_ID = "msmarco-v1-passage.trecdl2019";
+const defaultDataset = datasetCols.some((d: any) => d.id === DEFAULT_DATASET_ID)
+  ? DEFAULT_DATASET_ID
+  : (benchmarkGroups[0]?.datasets[0]?.id ?? "");
+const defaultBenchmark =
+  benchmarkGroups.find((g) => g.datasets.some((d) => d.id === defaultDataset))?.key
+  ?? benchmarkGroups[0]?.key
+  ?? "msmarco";
+
+// Pre-build reproduce steps for every run_id (used by expand panels)
 const runsMap = runs as Record<string, any>;
 type Step = { num: number; title: string; hint: string; code: string };
 const reproCache: Record<string, Step[]> = {};
@@ -107,511 +115,609 @@ function stepsFor(runId: string): Step[] | null {
   reproCache[runId] = steps;
   return steps;
 }
+
+// JSON-LD for SEO
+const jsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  name: "QueryGym Leaderboard",
+  description: "Reproducible benchmarks for LLM-based query reformulation across BEIR, MS MARCO DL, and DL-HARD — with click-to-reproduce commands for every result.",
+  url: "https://leaderboard.querygym.com/",
+  license: "https://www.apache.org/licenses/LICENSE-2.0",
+  isAccessibleForFree: true,
+  keywords: ["query reformulation","large language models","information retrieval","BEIR","MS MARCO","TREC Deep Learning","reproducibility","leaderboard"],
+  creator: { "@type": "Organization", name: "ls3-lab", url: "https://querygym.com", sameAs: ["https://github.com/ls3-lab"] },
+  sameAs: ["https://querygym.com","https://github.com/ls3-lab/QueryGym","https://arxiv.org/abs/2511.15996","https://arxiv.org/abs/2604.27421"],
+  variableMeasured: ["nDCG@10","Recall@100","Recall@1000"],
+});
 ---
 
 <Default
   title="Leaderboard"
-  description="Reproducible benchmarks for LLM query reformulation. Click any row to see the exact commands that produced each score — methods × LLMs × retrievers (BM25, SPLADE++, BGE) across BEIR, MS MARCO DL, and DL-HARD."
+  description="Reproducible benchmarks for LLM query reformulation. Select a dataset and retriever to compare methods — click any row for exact reproduce commands."
   jsonLd={jsonLd}
 >
-  {populated && (
-    <header class="mb-3">
-      <div class="mb-2 flex items-baseline gap-3">
-        <h2 class="text-xl font-semibold text-qg-fg md:text-2xl">Main Results</h2>
-        <div class="h-px flex-1 bg-qg-border"></div>
-        <span class="text-[11px] uppercase tracking-wider text-qg-fg-muted">
-          All results produced by
-          <span class="qg-mono font-semibold text-qg-accent">QueryGym</span>
-          · fully reproducible!
-        </span>
-      </div>
-      <p class="max-w-4xl text-xs leading-relaxed text-qg-fg-muted">
-        Query reformulation methods × LLMs × retrievers benchmarked across BEIR, MS MARCO DL, and DL-HARD.
-        <br />
-        Click any row or the <strong class="text-qg-fg">+</strong> button to expand. Tabs switch dataset
-        context. The three steps (reformulate → retrieve → evaluate) update accordingly.
-      </p>
-    </header>
-  )}
 
-  {populated && (
-    <div class="lb-filter-card" data-lb-filters>
-      <div class="lb-filter-row">
-        <div class="lb-filter-group" data-group="retriever">
-          <span class="lb-filter-label">Retriever</span>
-          <button class="lb-chip active" data-value="">All</button>
-          {retrievers.map((r: any) => (
-            <button class="lb-chip" data-value={r.id}>{r.display_name ?? r.id}</button>
+{populated && (
+  <header class="mb-4">
+    <div class="mb-2 flex items-baseline gap-3">
+      <h2 class="text-2xl font-semibold text-qg-fg md:text-3xl">Main Results</h2>
+      <div class="h-px flex-1 bg-qg-border"></div>
+      <span class="text-[12px] uppercase tracking-wider text-qg-fg-muted">
+        All results produced by
+        <span class="qg-mono font-semibold text-qg-accent">QueryGym</span>
+        · fully reproducible!
+      </span>
+    </div>
+    <p class="max-w-3xl text-sm leading-relaxed text-qg-fg-muted">
+      Select a dataset and retriever below, then filter by LLM or method.
+      Click any row to expand reproduce commands.
+    </p>
+  </header>
+)}
+
+{populated ? (
+  <>
+    {/* ── Selector card: Benchmark pills → Dataset dropdown → Retriever pills ── */}
+    <div class="lb-selector-card">
+      {/* Row 1: Benchmark */}
+      <div class="lb-selector-row">
+        <span class="lb-selector-label">Benchmark</span>
+        <div id="lb-bench-pills" class="lb-ret-pills">
+          {benchmarkGroups.map((g) => (
+            <button class:list={["lb-chip", g.key === defaultBenchmark && "active"]} data-bench={g.key}>
+              {g.label}
+            </button>
           ))}
         </div>
+      </div>
+      {/* Row 2: Dataset dropdown — populated entirely by JS on init */}
+      <div class="lb-selector-row">
+        <span class="lb-selector-label">Dataset</span>
+        <select id="lb-ds-select" class="lb-ds-select"></select>
+      </div>
+      {/* Row 3: Retriever */}
+      <div class="lb-selector-row">
+        <span class="lb-selector-label">Retriever</span>
+        <div class="lb-ret-pills" id="lb-ret-pills">
+          <button class="lb-chip active" data-ret="">All</button>
+          {retrievers.map((r: any) => (
+            <button class="lb-chip" data-ret={r.id}>{r.display_name ?? r.id}</button>
+          ))}
+        </div>
+      </div>
+    </div>
+
+    {/* ── Filter card: Model + Method chips + Search ── */}
+    <div class="lb-filter-card" data-lb-filters>
+      <div class="lb-filter-row">
         <div class="lb-filter-group" data-group="model">
-          <span class="lb-filter-label">Model</span>
+          <span class="lb-filter-label">LLM</span>
           <button class="lb-chip active" data-value="">All</button>
-          {models.map((m: any) => (
+          {(models as any[]).map((m) => (
             <button class="lb-chip" data-value={m.id}>{m.display ?? m.id}</button>
           ))}
         </div>
         <div class="lb-filter-group" data-group="method">
           <span class="lb-filter-label">Method</span>
           <button class="lb-chip active" data-value="">All</button>
-          {methods.map((m: any) => (
-            <button class="lb-chip" data-value={m.id}>{m.display_name ?? m.id}</button>
+          {(methods as any[]).map((m) => (
+            <button class="lb-chip" data-value={m.id}>{m.display ?? m.display_name ?? m.id}</button>
           ))}
-        </div>
-        <div class="lb-filter-group">
-          <span class="lb-filter-label">Datasets</span>
-          <div class="lb-multi" id="lb-ds-multi">
-            <button class="lb-multi-trigger" type="button" aria-haspopup="true">
-              <span class="lb-multi-count">{datasetCols.length} / {datasetCols.length} selected</span>
-              <span class="caret">▾</span>
-            </button>
-            <div class="lb-multi-panel" role="menu">
-              {beirCols.length > 0 && (
-                <div class="lb-multi-section" data-family="beir">
-                  <div class="lb-multi-section-head">
-                    <span class="label">BEIR</span>
-                    <span class="actions">
-                      <button type="button" data-action="all">all</button>
-                      <span>·</span>
-                      <button type="button" data-action="none">none</button>
-                    </span>
-                  </div>
-                  {beirCols.map((d: any) => (
-                    <label class="lb-multi-item">
-                      <input type="checkbox" data-ds={d.id} checked />
-                      <span class="name">{SHORT[d.id] ?? d.name}</span>
-                    </label>
-                  ))}
-                </div>
-              )}
-              {dlCols.length > 0 && (
-                <div class="lb-multi-section" data-family="dl">
-                  <div class="lb-multi-section-head">
-                    <span class="label">MS MARCO DL</span>
-                    <span class="actions">
-                      <button type="button" data-action="all">all</button>
-                      <span>·</span>
-                      <button type="button" data-action="none">none</button>
-                    </span>
-                  </div>
-                  {dlCols.map((d: any) => (
-                    <label class="lb-multi-item">
-                      <input type="checkbox" data-ds={d.id} checked />
-                      <span class="name">{SHORT[d.id] ?? d.name}</span>
-                    </label>
-                  ))}
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-        <div class="lb-filter-group">
-          <span class="lb-filter-label">Metric</span>
-          <div class="lb-seg" id="lb-metric-seg" role="tablist">
-            <button class="lb-seg-btn active" data-mode="both" role="tab">Both</button>
-            <button class="lb-seg-btn" data-mode="ndcg" role="tab">nDCG</button>
-            <button class="lb-seg-btn" data-mode="recall" role="tab">Recall</button>
-          </div>
         </div>
       </div>
       <div class="lb-filter-row">
         <div class="lb-search-wrap">
           <div class="lb-search-input">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>
-            <input id="lb-search" placeholder="Filter by method, model, retriever, dataset…" autocomplete="off" />
+            <input id="lb-search" placeholder="Filter by method or LLM…" autocomplete="off" />
           </div>
-          <span class="lb-row-count"><span id="lb-shown">{rows.length}</span> / {rows.length} configs · {overview.run_count} runs</span>
+          <span class="lb-row-count">
+            <span id="lb-shown">0</span> / {matrixRows.length} configs · {overview.run_count} runs
+          </span>
         </div>
-        <span class="lb-best-legend" style="margin-left:auto"><span class="dot"></span> best in column</span>
+        <span class="lb-best-legend" style="margin-left:auto">
+          <span class="dot"></span> best in column
+        </span>
       </div>
     </div>
-  )}
 
-  {populated ? (
+    {/* ── Table ── */}
     <div class="lb-table-card">
-      <div class="lb-table-scroll">
-        <table id="lb-matrix" class="lb">
+      <div class="lb-table-scroll" id="lb-scroll">
+        <table id="lb-matrix" class="lb lb-flat">
           <thead>
-            <tr class="top">
-              <th class="ax ax-1" rowspan="2"></th>
-              <th class="ax ax-2" rowspan="2">Method</th>
-              <th class="ax ax-3" rowspan="2">LLM</th>
-              <th class="ax ax-4" rowspan="2">Retriever</th>
-              {datasetCols.map((d: any) => (
-                <th class="group" colspan="2" data-ds={d.id} title={d.id}>{SHORT[d.id] ?? d.name}</th>
-              ))}
-            </tr>
-            <tr class="bot">
-              {datasetCols.map((d: any, di: number) => (
-                <>
-                  <th class:list={["metric", "metric-primary", di === 0 && "first"]} data-ds={d.id} data-sort-ds={d.id} data-sort-metric="primary">
-                    <span class="name">{METRIC_LABEL[d.primary_metric] ?? d.primary_metric}<span class="arrow"></span></span>
-                  </th>
-                  <th class="metric metric-secondary" data-ds={d.id} data-sort-ds={d.id} data-sort-metric="secondary">
-                    <span class="name">{METRIC_LABEL[d.secondary_metric] ?? d.secondary_metric}<span class="arrow"></span></span>
-                  </th>
-                </>
-              ))}
+            <tr>
+              <th class="lb-col-rank">#</th>
+              <th class="lb-col-method">Method</th>
+              <th class="lb-col-model">LLM</th>
+              <th id="lb-th-retriever" class="lb-col-retriever lb-hidden">Retriever</th>
+              <th id="lb-th-primary" class="lb-col-metric sortable" data-sort-metric="primary">
+                <span class="name">nDCG@10<span class="arrow"></span></span>
+              </th>
+              <th id="lb-th-secondary" class="lb-col-metric sortable" data-sort-metric="secondary">
+                <span class="name">R@100<span class="arrow"></span></span>
+              </th>
+              <th class="lb-col-exp"></th>
             </tr>
           </thead>
-          <tbody>
-            {rows.map((row: any, i: number) => {
-              const datasetsWithRuns = datasetCols.filter((d: any) => row.run_ids?.[d.id]);
-              const firstDsId = datasetsWithRuns[0]?.id;
-              return (
-                <>
-                  <tr
-                    class="data"
-                    data-idx={i}
-                    data-method={row.method_id}
-                    data-model={row.model}
-                    data-retriever={row.retriever_id}
-                  >
-                    <td class="ax ax-1"><button class="lb-exp-btn" aria-label="expand"></button></td>
-                    <td class="ax ax-2"><span class="lb-method-name">{row.method_display ?? row.method_id}</span></td>
-                    <td class="ax ax-3 qg-mono" style="font-size:11.5px">{row.model_display ?? row.model}</td>
-                    <td class="ax ax-4">{row.retriever_display ?? row.retriever_id}</td>
-                    {datasetCols.map((d: any, di: number) => {
-                      const cell = row.values?.[d.id] ?? {};
-                      const p = cell[d.primary_metric];
-                      const s = d.secondary_metric ? cell[d.secondary_metric] : null;
-                      const pTxt = p ? p.value.toFixed(4) : "—";
-                      const sTxt = s ? s.value.toFixed(4) : "—";
-                      const pBest = p?.best ? " best" : "";
-                      const sBest = s?.best ? " best" : "";
-                      const first = di === 0 ? " first" : "";
-                      return (
-                        <>
-                          <td
-                            class:list={["lb-metric-cell", "metric-primary", p?.best && "best", di === 0 && "first"]}
-                            data-ds={d.id}
-                            data-primary-value={p?.value ?? ""}
-                          ><span class="primary">{pTxt}</span></td>
-                          <td
-                            class:list={["lb-metric-cell", "metric-secondary", s?.best && "best"]}
-                            data-ds={d.id}
-                            data-secondary-value={s?.value ?? ""}
-                          ><span class="secondary">{sTxt}</span></td>
-                        </>
-                      );
-                    })}
-                  </tr>
-                  <tr class="lb-exp-row">
-                    <td colspan={4 + datasetCols.length * 2}>
-                      <div class="lb-exp-wrap"><div class="lb-exp-inner">
-                        <div class="lb-exp-panel">
-                          <div class="lb-exp-meta">
-                            <span class="pill"><strong>method</strong>{row.method_display ?? row.method_id}</span>
-                            <span class="pill"><strong>llm</strong>{row.model_display ?? row.model}</span>
-                            <span class="pill"><strong>retriever</strong>{row.retriever_display ?? row.retriever_id}</span>
-                          </div>
-                          {datasetsWithRuns.length > 0 ? (
-                            <>
-                              <div class="lb-tabs" role="tablist">
-                                {datasetsWithRuns.map((d: any, ti: number) => {
-                                  const cell = row.values?.[d.id] ?? {};
-                                  const p = cell[d.primary_metric];
-                                  return (
-                                    <button class:list={["lb-tab", ti === 0 && "active"]} data-tab={d.id}>
-                                      {SHORT[d.id] ?? d.name}
-                                      {p && <span class="score">{p.value.toFixed(3)}</span>}
-                                    </button>
-                                  );
-                                })}
-                              </div>
-                              <div>
-                                {datasetsWithRuns.map((d: any, ti: number) => {
-                                  const runId = row.run_ids[d.id];
-                                  const steps = stepsFor(runId);
-                                  return (
-                                    <div class:list={["lb-tab-pane", ti === 0 && "active"]} data-pane={d.id}>
-                                      {steps?.map((st) => (
-                                        <div class="lb-step">
-                                          <div class="lb-step-head">
-                                            <div class="title">
-                                              <span class="num">{st.num}</span>
-                                              {st.title}
-                                              <span class="hint">{st.hint}</span>
-                                            </div>
-                                            <button class="lb-copy-btn" data-copy>copy</button>
-                                          </div>
-                                          <pre>{st.code}</pre>
-                                        </div>
-                                      ))}
-                                      <div class="lb-exp-footer">
-                                        <span>Run id <span class="qg-mono">{runId}</span></span>
-                                        <span>·</span>
-                                        <a href={`/runs/${runId}`}>open full run detail →</a>
-                                      </div>
-                                    </div>
-                                  );
-                                })}
-                              </div>
-                            </>
-                          ) : (
-                            <div class="text-sm text-qg-fg-muted">No runs recorded for this configuration.</div>
-                          )}
-                        </div>
-                      </div></div>
-                    </td>
-                  </tr>
-                </>
-              );
-            })}
+          <tbody id="lb-tbody">
+            {/* Built by JS */}
           </tbody>
         </table>
       </div>
     </div>
-  ) : (
-    <div class="mt-8 rounded-lg border border-qg-border bg-qg-bg-soft p-6 text-qg-fg-muted">
-      No runs yet. The matrix will populate when results land.
+
+    {/* ── Hidden expand-panel templates (pre-rendered at build time) ── */}
+    <div id="lb-exp-templates" hidden>
+      {matrixRows.map((row: any) => {
+        const rowKey = `${row.method_id}||${row.model}||${row.retriever_id}`;
+        const datasetsWithRuns = datasetCols.filter((d: any) => row.run_ids?.[d.id]);
+        return (
+          <div data-row-key={rowKey}>
+            <div class="lb-exp-panel">
+              <div class="lb-exp-meta">
+                <span class="pill"><strong>method</strong>{row.method_display ?? row.method_id}</span>
+                <span class="pill"><strong>llm</strong>{row.model_display ?? row.model}</span>
+                <span class="pill"><strong>retriever</strong>{row.retriever_display ?? row.retriever_id}</span>
+              </div>
+              {datasetsWithRuns.length > 0 ? (
+                <div class="lb-exp-body">
+                  {/* ── Left: dataset tabs + reproduce commands ── */}
+                  <div class="lb-exp-commands">
+                    <div class="lb-tabs" role="tablist">
+                      {datasetsWithRuns.map((d: any, ti: number) => {
+                        const cell = row.values?.[d.id] ?? {};
+                        const p = cell[d.primary_metric];
+                        return (
+                          <button class:list={["lb-tab", ti === 0 && "active"]} data-tab={d.id}>
+                            {SHORT[d.id] ?? d.name}
+                            {p && <span class="score">{p.value.toFixed(3)}</span>}
+                          </button>
+                        );
+                      })}
+                    </div>
+                    <div>
+                      {datasetsWithRuns.map((d: any, ti: number) => {
+                        const runId = row.run_ids[d.id];
+                        const steps = stepsFor(runId);
+                        return (
+                          <div class:list={["lb-tab-pane", ti === 0 && "active"]} data-pane={d.id}>
+                            {steps?.map((st) => (
+                              <div class="lb-step">
+                                <div class="lb-step-head">
+                                  <div class="title">
+                                    <span class="num">{st.num}</span>
+                                    {st.title}
+                                    <span class="hint">{st.hint}</span>
+                                  </div>
+                                  <button class="lb-copy-btn" data-copy>copy</button>
+                                </div>
+                                <pre>{st.code}</pre>
+                              </div>
+                            ))}
+                            <div class="lb-exp-footer">
+                              <span>Run id <span class="qg-mono">{runId}</span></span>
+                              <span>·</span>
+                              <a href={`/runs/${runId}`}>open full run detail →</a>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                  {/* ── Right: per-dataset bar chart ── */}
+                  <div class="lb-exp-barchart-wrap">
+                    <div class="lb-barchart-title">Per-dataset · nDCG@10</div>
+                    {datasetsWithRuns.map((d: any, ti: number) => {
+                      const val = (row.values?.[d.id] ?? {})[d.primary_metric]?.value;
+                      const pct = val != null ? (val * 100).toFixed(1) : 0;
+                      return (
+                        <div class:list={["lb-bar-row", ti === 0 && "active"]} data-bar-ds={d.id}>
+                          <span class="lb-bar-label">{SHORT[d.id] ?? d.name}</span>
+                          <div class="lb-bar-track">
+                            <div class="lb-bar" style={`width: ${pct}%`}></div>
+                          </div>
+                          <span class="lb-bar-val">{val != null ? val.toFixed(3) : "—"}</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : (
+                <div class="text-sm text-qg-fg-muted">No runs recorded for this configuration.</div>
+              )}
+            </div>
+          </div>
+        );
+      })}
     </div>
-  )}
+  </>
+) : (
+  <div class="mt-8 rounded-lg border border-qg-border bg-qg-bg-soft p-6 text-qg-fg-muted">
+    No runs yet. The leaderboard will populate when results land.
+  </div>
+)}
 
 </Default>
 
-<script>
-  // ------ viewport-width tracker for expand panel ------------------------
-  // The expand row's td has full table width via colspan, but we sticky-left
-  // its inner wrap and clamp it to the scroll container's visible width so
-  // the panel content always fits on screen and doesn't push horizontal
-  // scroll. JS sets --lb-vp-w on the scroll container; CSS uses it.
-  const scrollEl = document.querySelector<HTMLElement>(".lb-table-scroll");
+<script define:vars={{
+  matrixRowsData:   matrixRows,
+  datasetColsData:  datasetCols,
+  benchmarkGroupsData: benchmarkGroups,
+  defaultDatasetId: defaultDataset,
+  defaultBenchmarkKey: defaultBenchmark,
+  SHORT,
+  METRIC_LABEL,
+  methodsData:      methods,
+  modelsData:       models,
+}}>
+  // ------ viewport-width tracker for expand panel (sticky positioning) -------
+  const scrollEl = document.getElementById("lb-scroll");
   function updateVp() {
     if (scrollEl) scrollEl.style.setProperty("--lb-vp-w", scrollEl.clientWidth + "px");
   }
   updateVp();
   window.addEventListener("resize", updateVp);
 
-  // ------ filter chips (Retriever / Model / Method) ----------------------
-  const filterRoot = document.querySelector<HTMLElement>("[data-lb-filters]");
-  const table = document.getElementById("lb-matrix") as HTMLTableElement | null;
-  const tbody = table?.querySelector("tbody");
-  const search = document.getElementById("lb-search") as HTMLInputElement | null;
-  const shownEl = document.getElementById("lb-shown");
+  // ------ benchmark lookup (keyed by benchmark key) ---------------------------
+  // benchmarkGroupsData: [{ key, label, datasets: [{id, name}] }]
+  const BENCH_MAP = {};
+  benchmarkGroupsData.forEach((g) => { BENCH_MAP[g.key] = g.datasets; });
 
-  const filterState: Record<string, string> = { retriever: "", model: "", method: "" };
+  // ------ state ---------------------------------------------------------------
+  const state = {
+    benchmark:  defaultBenchmarkKey ?? benchmarkGroupsData[0]?.key ?? "msmarco",
+    dataset:    defaultDatasetId,
+    retriever:  "",
+    model:      "",
+    method:     "",
+    query:      "",
+    sortMetric: "primary",
+    sortDir:    "desc",
+  };
 
-  filterRoot?.querySelectorAll<HTMLElement>("[data-group]").forEach((g) => {
-    const key = g.dataset.group!;
-    if (key === "metric") return;
-    g.querySelectorAll<HTMLButtonElement>("button.lb-chip").forEach((btn) => {
+  // ------ color maps (stable: sorted order matches build-data output) ---------
+  // Methods use lb-mtag-{0..9}, models use lb-mdtag-{0..5}.
+  // Indices are assigned by alphabetical sort order so they never shift when
+  // new runs are added — only when a genuinely new method/model appears.
+  const methodColorMap = {};
+  (methodsData ?? []).forEach((m, i) => { methodColorMap[m.id] = i % 10; });
+  const modelColorMap = {};
+  (modelsData ?? []).forEach((m, i) => { modelColorMap[m.id] = i % 6; });
+
+  // ------ DOM refs ------------------------------------------------------------
+  const tbody     = document.getElementById("lb-tbody");
+  const shownEl   = document.getElementById("lb-shown");
+  const thPrimary = document.getElementById("lb-th-primary");
+  const thSec     = document.getElementById("lb-th-secondary");
+  const thRet     = document.getElementById("lb-th-retriever");
+  const expTpls   = document.getElementById("lb-exp-templates");
+
+  // Build a Map for O(1) template lookup (row keys contain "/" which breaks CSS selector)
+  const tplMap = new Map();
+  expTpls?.querySelectorAll("[data-row-key]").forEach((el) => {
+    tplMap.set(el.dataset.rowKey, el);
+  });
+
+  // ------ benchmark pills + dataset dropdown ----------------------------------
+  const dsSelect = document.getElementById("lb-ds-select");
+
+  function repopulateDatasetSelect(benchKey) {
+    if (!dsSelect) return;
+    const datasets = BENCH_MAP[benchKey] ?? [];
+    dsSelect.innerHTML = datasets
+      .map((d) => `<option value="${d.id}">${d.name}</option>`)
+      .join("");
+    // Preserve current dataset if it exists in the new benchmark; else first
+    const ids = datasets.map((d) => d.id);
+    state.dataset = ids.includes(state.dataset) ? state.dataset : (ids[0] ?? "");
+    dsSelect.value = state.dataset;
+  }
+
+  document.querySelectorAll("#lb-bench-pills button").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      document.querySelectorAll("#lb-bench-pills button").forEach((b) => b.classList.remove("active"));
+      btn.classList.add("active");
+      state.benchmark = btn.dataset.bench ?? "";
+      repopulateDatasetSelect(state.benchmark);
+      renderTable();
+    });
+  });
+
+  dsSelect?.addEventListener("change", (e) => {
+    state.dataset = e.target.value;
+    renderTable();
+  });
+
+  // ------ retriever pills -----------------------------------------------------
+  document.querySelectorAll("#lb-ret-pills button").forEach((btn) => {
+    // Seed state from whichever pill is active on load (the "All" pill = "")
+    if (btn.classList.contains("active")) state.retriever = btn.dataset.ret ?? "";
+    btn.addEventListener("click", () => {
+      document.querySelectorAll("#lb-ret-pills button").forEach((b) => b.classList.remove("active"));
+      btn.classList.add("active");
+      state.retriever = btn.dataset.ret ?? "";
+      renderTable();
+    });
+  });
+
+  // ------ model / method chips ------------------------------------------------
+  const filterState = { model: "", method: "" };
+  document.querySelectorAll("[data-lb-filters] [data-group]").forEach((g) => {
+    const key = g.dataset.group;
+    g.querySelectorAll("button.lb-chip").forEach((btn) => {
       btn.addEventListener("click", () => {
         g.querySelectorAll("button.lb-chip").forEach((b) => b.classList.remove("active"));
         btn.classList.add("active");
         filterState[key] = btn.dataset.value ?? "";
-        applyVisibility();
+        renderTable();
       });
     });
   });
 
-  function applyVisibility() {
-    if (!tbody) return;
-    const q = (search?.value ?? "").trim().toLowerCase();
-    let shown = 0;
-    tbody.querySelectorAll<HTMLTableRowElement>("tr.data").forEach((tr) => {
-      let hide = false;
-      for (const [k, v] of Object.entries(filterState)) {
-        if (v && tr.dataset[k] !== v) { hide = true; break; }
-      }
-      if (!hide && q) {
-        const txt = (tr.textContent ?? "").toLowerCase();
-        if (!txt.includes(q)) hide = true;
-      }
-      tr.style.display = hide ? "none" : "";
-      const exp = tr.nextElementSibling as HTMLElement | null;
-      if (exp?.classList.contains("lb-exp-row")) exp.style.display = hide ? "none" : "";
-      if (!hide) shown++;
-    });
-    if (shownEl) shownEl.textContent = String(shown);
-  }
-  search?.addEventListener("input", applyVisibility);
-
-  // ------ dataset multi-select dropdown ---------------------------------
-  const dsMulti = document.getElementById("lb-ds-multi");
-  const dsTrigger = dsMulti?.querySelector<HTMLButtonElement>(".lb-multi-trigger");
-  const dsCount = dsMulti?.querySelector<HTMLElement>(".lb-multi-count");
-  const dsPanel = dsMulti?.querySelector<HTMLElement>(".lb-multi-panel");
-  const dsCheckboxes = Array.from(dsMulti?.querySelectorAll<HTMLInputElement>('input[type="checkbox"][data-ds]') ?? []);
-
-  dsTrigger?.addEventListener("click", (e) => {
-    e.stopPropagation();
-    dsMulti?.classList.toggle("open");
+  // ------ search --------------------------------------------------------------
+  document.getElementById("lb-search")?.addEventListener("input", (e) => {
+    state.query = e.target.value.trim().toLowerCase();
+    renderTable();
   });
-  dsPanel?.addEventListener("click", (e) => e.stopPropagation());
-  document.addEventListener("click", () => dsMulti?.classList.remove("open"));
 
-  dsCheckboxes.forEach((cb) => cb.addEventListener("change", applyDsFilter));
-
-  dsMulti?.querySelectorAll<HTMLButtonElement>('button[data-action]').forEach((btn) => {
-    btn.addEventListener("click", (e) => {
-      e.stopPropagation();
-      const fam = btn.closest<HTMLElement>("[data-family]")?.dataset.family;
-      const isAll = btn.dataset.action === "all";
-      dsCheckboxes.forEach((cb) => {
-        const dsId = cb.dataset.ds ?? "";
-        const cbFam = dsId.startsWith("beir-") ? "beir" : "dl";
-        if (cbFam === fam) cb.checked = isAll;
-      });
-      applyDsFilter();
+  // ------ sort headers --------------------------------------------------------
+  [thPrimary, thSec].forEach((th) => {
+    if (!th) return;
+    th.addEventListener("click", () => {
+      const m = th.dataset.sortMetric;
+      if (state.sortMetric === m) {
+        state.sortDir = state.sortDir === "desc" ? "asc" : "desc";
+      } else {
+        state.sortMetric = m;
+        state.sortDir = "desc";
+      }
+      updateSortIndicators();
+      renderTable();
     });
   });
 
-  function applyDsFilter() {
-    const hidden = new Set<string>();
-    dsCheckboxes.forEach((cb) => { if (!cb.checked) hidden.add(cb.dataset.ds ?? ""); });
-    // hide column elements (group ths, metric subheader ths, body cells).
-    // Use lb-hide-ds so this state is independent of the metric-mode toggle.
-    document.querySelectorAll<HTMLElement>("table.lb [data-ds]").forEach((el) => {
-      el.classList.toggle("lb-hide-ds", hidden.has(el.dataset.ds ?? ""));
-    });
-    // hide tabs + panes in any expanded row
-    document.querySelectorAll<HTMLElement>(".lb-tab").forEach((tab) => {
-      tab.classList.toggle("lb-hide-ds", hidden.has(tab.dataset.tab ?? ""));
-    });
-    document.querySelectorAll<HTMLElement>(".lb-tab-pane").forEach((p) => {
-      p.classList.toggle("lb-hide-ds", hidden.has(p.dataset.pane ?? ""));
-    });
-    // if a panel's active tab is now hidden, activate the first visible one
-    document.querySelectorAll<HTMLElement>(".lb-exp-row").forEach((exp) => {
-      const activeTab = exp.querySelector<HTMLElement>(".lb-tab.active:not(.lb-hide-ds)");
-      if (!activeTab) {
-        const firstVisible = exp.querySelector<HTMLElement>(".lb-tab:not(.lb-hide-ds)");
-        if (firstVisible) {
-          exp.querySelectorAll<HTMLElement>(".lb-tab").forEach((t) => t.classList.remove("active"));
-          firstVisible.classList.add("active");
-          const id = firstVisible.dataset.tab;
-          exp.querySelectorAll<HTMLElement>(".lb-tab-pane").forEach((p) =>
-            p.classList.toggle("active", p.dataset.pane === id && !p.classList.contains("lb-hide-ds"))
-          );
-        }
-      }
-    });
-    // update trigger label
-    const total = dsCheckboxes.length;
-    const selected = dsCheckboxes.filter((c) => c.checked).length;
-    if (dsCount) dsCount.textContent = `${selected} / ${total} selected`;
-    dsTrigger?.classList.toggle("has-filter", selected < total);
-  }
-
-  // ------ metric segmented control --------------------------------------
-  let metricMode: "both" | "ndcg" | "recall" = "both";
-  const segBtns = document.querySelectorAll<HTMLButtonElement>("#lb-metric-seg .lb-seg-btn");
-  segBtns.forEach((btn) => {
-    btn.addEventListener("click", () => {
-      if (btn.classList.contains("active")) return;
-      segBtns.forEach((b) => b.classList.toggle("active", b === btn));
-      metricMode = (btn.dataset.mode as any) ?? "both";
-      applyMetricMode();
-    });
-  });
-  function applyMetricMode() {
-    if (!table) return;
-    const showP = metricMode === "ndcg" || metricMode === "both";
-    const showS = metricMode === "recall" || metricMode === "both";
-    table.classList.toggle("mode-single", !(showP && showS));
-    // use lb-hide-metric so this state is independent of the ds-filter
-    table.querySelectorAll(".metric-primary").forEach((el) => el.classList.toggle("lb-hide-metric", !showP));
-    table.querySelectorAll(".metric-secondary").forEach((el) => el.classList.toggle("lb-hide-metric", !showS));
-    const newSpan = (showP ? 1 : 0) + (showS ? 1 : 0);
-    table.querySelectorAll<HTMLTableCellElement>("thead tr.top th.group").forEach((th) => { th.colSpan = newSpan || 1; });
-    // re-flow the .first class so the leftmost visible metric in each group keeps the border
-    const datasets = Array.from(table.querySelectorAll<HTMLTableCellElement>("thead tr.top th.group")).map((th) => th.dataset.ds);
-    datasets.forEach((dsId, di) => {
-      const p = table!.querySelector<HTMLElement>(`thead tr.bot .metric-primary[data-sort-ds="${dsId}"]`);
-      const s = table!.querySelector<HTMLElement>(`thead tr.bot .metric-secondary[data-sort-ds="${dsId}"]`);
-      if (p) p.classList.toggle("first", di === 0 && showP);
-      if (s) s.classList.toggle("first", di === 0 && !showP);
-    });
-    table.querySelectorAll<HTMLTableRowElement>("tbody tr.data").forEach((tr) => {
-      datasets.forEach((dsId, di) => {
-        const ps = tr.querySelectorAll<HTMLElement>(".metric-primary");
-        const ss = tr.querySelectorAll<HTMLElement>(".metric-secondary");
-        const p = ps[di]; const s = ss[di];
-        if (p) p.classList.toggle("first", di === 0 && showP);
-        if (s) s.classList.toggle("first", di === 0 && !showP);
-      });
-    });
-    // re-apply current sort if any (so order matches what's visible)
-    if (sortState.dsId) applySort();
-  }
-
-  // ------ sort ----------------------------------------------------------
-  const sortState: { dsId: string | null; metric: "primary" | "secondary" | null; dir: "asc" | "desc" | null } = {
-    dsId: null, metric: null, dir: null,
-  };
-  function applySort() {
-    if (!tbody || !sortState.dsId || !sortState.dir) return;
-    const dsId = sortState.dsId;
-    const attr = sortState.metric === "primary" ? "primaryValue" : "secondaryValue";
-    const dir = sortState.dir === "asc" ? 1 : -1;
-    const dsIdx = Array.from(table!.querySelectorAll<HTMLTableCellElement>("thead tr.top th.group")).findIndex((th) => th.dataset.ds === dsId);
-    if (dsIdx < 0) return;
-    const dataRows = Array.from(tbody.querySelectorAll<HTMLTableRowElement>("tr.data"));
-    const pairs = dataRows.map((tr) => {
-      const cells = tr.querySelectorAll<HTMLTableCellElement>(sortState.metric === "primary" ? ".metric-primary" : ".metric-secondary");
-      const cell = cells[dsIdx];
-      const raw = cell?.dataset[attr] ?? "";
-      const n = parseFloat(raw);
-      return { tr, exp: tr.nextElementSibling, v: Number.isFinite(n) ? n : null };
-    });
-    pairs.sort((a, b) => {
-      if (a.v === null && b.v === null) return 0;
-      if (a.v === null) return 1;
-      if (b.v === null) return -1;
-      return (a.v - b.v) * dir;
-    });
-    pairs.forEach((p) => {
-      tbody!.appendChild(p.tr);
-      if (p.exp) tbody!.appendChild(p.exp);
-    });
-  }
   function updateSortIndicators() {
-    table?.querySelectorAll(".metric").forEach((th) => th.classList.remove("sort-asc", "sort-desc"));
-    if (sortState.dir) {
-      const th = table?.querySelector(`thead .metric[data-sort-ds="${sortState.dsId}"][data-sort-metric="${sortState.metric}"]`);
-      th?.classList.add(`sort-${sortState.dir}`);
-    }
+    [thPrimary, thSec].forEach((th) => {
+      if (!th) return;
+      th.classList.remove("sort-asc", "sort-desc");
+      if (th.dataset.sortMetric === state.sortMetric) {
+        th.classList.add(`sort-${state.sortDir}`);
+      }
+    });
   }
-  function setSort(dsId: string, metric: "primary" | "secondary") {
-    if (sortState.dsId === dsId && sortState.metric === metric) {
-      sortState.dir = sortState.dir === "desc" ? "asc" : "desc";
-    } else {
-      sortState.dsId = dsId; sortState.metric = metric; sortState.dir = "desc";
+
+  // ------ helpers -------------------------------------------------------------
+  function escHtml(str) {
+    return String(str ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+
+  function rankBadge(rank) {
+    const cls =
+      rank === 1 ? "lb-rank lb-rank-1" :
+      rank === 2 ? "lb-rank lb-rank-2" :
+      rank === 3 ? "lb-rank lb-rank-3" : "lb-rank lb-rank-n";
+    return `<span class="${cls}">${rank}</span>`;
+  }
+
+  function getDsCol() {
+    return datasetColsData.find((d) => d.id === state.dataset);
+  }
+
+  // ------ renderTable ---------------------------------------------------------
+  function renderTable() {
+    const dsCol = getDsCol();
+    if (!dsCol || !tbody) return;
+
+    const primaryMetric   = dsCol.primary_metric;
+    const secondaryMetric = dsCol.secondary_metric;
+
+    // Update column header labels (preserve the .arrow child span)
+    function setThLabel(th, label) {
+      if (!th) return;
+      const nameSpan = th.querySelector(".name");
+      if (nameSpan) {
+        const arrow = nameSpan.querySelector(".arrow");
+        nameSpan.textContent = label;
+        if (arrow) nameSpan.appendChild(arrow);
+      }
     }
-    applySort();
+    setThLabel(thPrimary, METRIC_LABEL[primaryMetric] ?? primaryMetric ?? "");
+    setThLabel(thSec,     METRIC_LABEL[secondaryMetric] ?? secondaryMetric ?? "");
+    if (thPrimary)  thPrimary.style.display  = primaryMetric   ? "" : "none";
+    if (thSec)      thSec.style.display      = secondaryMetric ? "" : "none";
+
+    const showRetrieverCol = !state.retriever;
+    if (thRet) thRet.classList.toggle("lb-hidden", !showRetrieverCol);
+
+    // 1. Filter
+    const filtered = matrixRowsData.filter((row) => {
+      if (state.retriever && row.retriever_id !== state.retriever) return false;
+      if (!row.values?.[state.dataset]) return false;
+      if (filterState.model && row.model !== filterState.model) return false;
+      if (filterState.method && row.method_id !== filterState.method) return false;
+      if (state.query) {
+        const txt = [
+          row.method_display ?? row.method_id,
+          row.model_display ?? row.model,
+          row.retriever_display ?? row.retriever_id,
+        ].join(" ").toLowerCase();
+        if (!txt.includes(state.query)) return false;
+      }
+      return true;
+    });
+
+    // 2. Sort
+    filtered.sort((a, b) => {
+      const metric = state.sortMetric === "primary" ? primaryMetric : secondaryMetric;
+      if (!metric) return 0;
+      const av = a.values?.[state.dataset]?.[metric]?.value ?? -Infinity;
+      const bv = b.values?.[state.dataset]?.[metric]?.value ?? -Infinity;
+      if (av === bv) return 0;
+      return state.sortDir === "desc" ? bv - av : av - bv;
+    });
+
+    // 3. Best-in-column for local highlighting
+    let bestP = -Infinity, bestS = -Infinity;
+    for (const row of filtered) {
+      const cell = row.values?.[state.dataset] ?? {};
+      const pv = cell[primaryMetric]?.value;
+      const sv = secondaryMetric ? cell[secondaryMetric]?.value : null;
+      if (pv != null && pv > bestP) bestP = pv;
+      if (sv != null && sv > bestS) bestS = sv;
+    }
+
+    // 4. Compute ranks (competition ranking: ties share rank, next rank jumps).
+    //    Rank is always relative to the currently sorted metric so badges stay
+    //    consistent with the displayed row order.
+    const rankMetric = state.sortMetric === "primary" ? primaryMetric : (secondaryMetric ?? primaryMetric);
+    const ranks = [];
+    for (let i = 0; i < filtered.length; i++) {
+      if (i === 0) {
+        ranks.push(1);
+      } else {
+        const prevPv = filtered[i - 1].values?.[state.dataset]?.[rankMetric]?.value;
+        const curPv  = filtered[i].values?.[state.dataset]?.[rankMetric]?.value;
+        ranks.push(curPv === prevPv ? ranks[i - 1] : i + 1);
+      }
+    }
+
+    // 5. Build HTML
+    const html = filtered.map((row, i) => {
+      const cell = row.values?.[state.dataset] ?? {};
+      const pv = cell[primaryMetric]?.value;
+      const sv = secondaryMetric ? cell[secondaryMetric]?.value : null;
+      const pBest = pv != null && pv === bestP;
+      const sBest = sv != null && sv === bestS;
+      const pvStr = pv != null ? pv.toFixed(4) : "—";
+      const svStr = sv != null ? sv.toFixed(4) : "—";
+      const rowKey = `${row.method_id}||${row.model}||${row.retriever_id}`;
+
+      const mTagIdx  = methodColorMap[row.method_id] ?? 0;
+      const mdTagIdx = modelColorMap[row.model] ?? 0;
+      const retrieverCell = showRetrieverCol
+        ? `<td class="lb-col-retriever">${escHtml(row.retriever_display ?? row.retriever_id)}</td>`
+        : "";
+      const colSpan = showRetrieverCol ? 7 : 6;
+      return `
+<tr class="data" data-row-key="${escHtml(rowKey)}" data-method="${escHtml(row.method_id)}" data-model="${escHtml(row.model)}" data-retriever="${escHtml(row.retriever_id)}">
+  <td class="lb-col-rank">${rankBadge(ranks[i])}</td>
+  <td class="lb-col-method"><span class="lb-badge lb-mtag-${mTagIdx}">${escHtml(row.method_display ?? row.method_id)}</span></td>
+  <td class="lb-col-model"><span class="lb-badge lb-mono lb-mdtag-${mdTagIdx}">${escHtml(row.model_display ?? row.model)}</span></td>
+  ${retrieverCell}
+  <td class="lb-col-metric${pBest ? " best" : ""}" data-primary-value="${pv ?? ""}">
+    <span class="metric-val">${pvStr}</span>
+  </td>
+  <td class="lb-col-metric secondary${sBest ? " best" : ""}${secondaryMetric ? "" : " lb-hidden"}" data-secondary-value="${sv ?? ""}">
+    <span class="metric-val">${svStr}</span>
+  </td>
+  <td class="lb-col-exp"><button class="lb-exp-btn" aria-label="expand row"></button></td>
+</tr>
+<tr class="lb-exp-row" data-row-key="${escHtml(rowKey)}">
+  <td colspan="${colSpan}">
+    <div class="lb-exp-wrap"><div class="lb-exp-inner"></div></div>
+  </td>
+</tr>`;
+    }).join("");
+
+    tbody.innerHTML = html;
+    if (shownEl) shownEl.textContent = String(filtered.length);
+
+    // 6. Attach expand-row handlers
+    attachExpandHandlers();
     updateSortIndicators();
   }
-  table?.querySelectorAll<HTMLElement>("thead .metric").forEach((th) => {
-    th.addEventListener("click", () => {
-      const dsId = th.dataset.sortDs;
-      const m = th.dataset.sortMetric as "primary" | "secondary" | undefined;
-      if (dsId && m) setSort(dsId, m);
-    });
-  });
 
-  // ------ row expand + tab switching ------------------------------------
-  tbody?.querySelectorAll<HTMLTableRowElement>("tr.data").forEach((tr) => {
-    const exp = tr.nextElementSibling as HTMLElement | null;
-    if (!exp?.classList.contains("lb-exp-row")) return;
-    const toggle = (e?: Event) => {
-      if (e && (e.target as HTMLElement).closest("a, button.lb-copy-btn, button.lb-tab")) return;
-      const open = tr.classList.toggle("expanded");
-      exp.classList.toggle("show", open);
-    };
-    tr.addEventListener("click", toggle);
-    exp.querySelectorAll<HTMLButtonElement>(".lb-tab").forEach((tab) => {
-      tab.addEventListener("click", () => {
-        exp.querySelectorAll(".lb-tab").forEach((t) => t.classList.toggle("active", t === tab));
-        const id = tab.dataset.tab;
-        exp.querySelectorAll<HTMLElement>(".lb-tab-pane").forEach((p) => p.classList.toggle("active", p.dataset.pane === id));
+  // ------ expand panel logic --------------------------------------------------
+  function attachExpandHandlers() {
+    if (!tbody) return;
+    tbody.querySelectorAll("tr.data").forEach((tr) => {
+      const expRow = tr.nextElementSibling;
+      if (!expRow?.classList.contains("lb-exp-row")) return;
+
+      tr.addEventListener("click", (e) => {
+        if (e.target.closest("a, button.lb-copy-btn, button.lb-tab")) return;
+        const wasOpen = tr.classList.contains("expanded");
+
+        // Close all open rows first
+        tbody.querySelectorAll("tr.data.expanded").forEach((r) => {
+          r.classList.remove("expanded");
+          const sibling = r.nextElementSibling;
+          if (sibling?.classList.contains("lb-exp-row")) sibling.classList.remove("show");
+        });
+
+        if (!wasOpen) {
+          tr.classList.add("expanded");
+          expRow.classList.add("show");
+
+          // Inject expand panel on first open
+          const inner = expRow.querySelector(".lb-exp-inner");
+          if (inner && inner.children.length === 0) {
+            const rowKey = tr.dataset.rowKey;
+            const tpl = tplMap.get(rowKey);
+            if (tpl) {
+              const panel = tpl.querySelector(".lb-exp-panel").cloneNode(true);
+              inner.appendChild(panel);
+              // Activate the tab for the currently selected dataset
+              activateDatasetTab(inner, state.dataset);
+              // Attach tab-switch handlers
+              inner.querySelectorAll(".lb-tab").forEach((tab) => {
+                tab.addEventListener("click", () => {
+                  inner.querySelectorAll(".lb-tab").forEach((t) =>
+                    t.classList.toggle("active", t === tab)
+                  );
+                  const id = tab.dataset.tab;
+                  inner.querySelectorAll(".lb-tab-pane").forEach((p) =>
+                    p.classList.toggle("active", p.dataset.pane === id)
+                  );
+                  // Sync bar chart highlight
+                  inner.querySelectorAll(".lb-bar-row").forEach((b) =>
+                    b.classList.toggle("active", b.dataset.barDs === id)
+                  );
+                });
+              });
+            }
+          }
+        }
       });
     });
-  });
+  }
 
-  // ------ copy buttons --------------------------------------------------
+  function activateDatasetTab(container, dsId) {
+    const tabs  = container.querySelectorAll(".lb-tab");
+    const panes = container.querySelectorAll(".lb-tab-pane");
+    const bars  = container.querySelectorAll(".lb-bar-row");
+    let found = false;
+    let activeTab = null;
+    tabs.forEach((t) => {
+      const match = t.dataset.tab === dsId;
+      t.classList.toggle("active", match);
+      if (match) { found = true; activeTab = t; }
+    });
+    panes.forEach((p) => p.classList.toggle("active", p.dataset.pane === dsId));
+    bars.forEach((b)  => b.classList.toggle("active",  b.dataset.barDs === dsId));
+    // Fall back to first tab if current dataset not in this row's runs
+    if (!found && tabs.length > 0) {
+      tabs[0].classList.add("active");
+      activeTab = tabs[0];
+      const firstId = tabs[0].dataset.tab;
+      panes.forEach((p) => p.classList.toggle("active", p.dataset.pane === firstId));
+      bars.forEach((b)  => b.classList.toggle("active",  b.dataset.barDs === firstId));
+    }
+    // Scroll the active tab into view within the tab strip
+    if (activeTab) {
+      activeTab.scrollIntoView({ block: "nearest", inline: "nearest" });
+    }
+  }
+
+  // ------ copy buttons (delegated) -------------------------------------------
   document.addEventListener("click", (e) => {
-    const btn = (e.target as HTMLElement).closest<HTMLButtonElement>("[data-copy]");
+    const btn = e.target.closest("[data-copy]");
     if (!btn) return;
     const pre = btn.closest(".lb-step")?.querySelector("pre");
     if (!pre) return;
@@ -619,6 +725,15 @@ function stepsFor(runId: string): Step[] | null {
     const prev = btn.textContent;
     btn.textContent = "copied ✓";
     btn.classList.add("copied");
-    setTimeout(() => { btn.textContent = prev; btn.classList.remove("copied"); }, 1400);
+    setTimeout(() => {
+      btn.textContent = prev;
+      btn.classList.remove("copied");
+    }, 1400);
   });
+
+  // ------ initial render ------------------------------------------------------
+  // Populate dataset select for the default benchmark before first render
+  repopulateDatasetSelect(state.benchmark);
+  updateSortIndicators();
+  renderTable();
 </script>

--- a/reproducibility/site/src/styles/global.css
+++ b/reproducibility/site/src/styles/global.css
@@ -1,7 +1,18 @@
 @import "@qg/shared/tokens.css";
+@import url('https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,400;0,600;1,400&family=IBM+Plex+Mono:wght@400;500&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Override design-token font variables so the whole leaderboard page uses the
+   HuggingFace / Gradio default font stack (Source Sans 3 + IBM Plex Mono). */
+:root {
+  --qg-font-sans: 'Source Sans 3', 'Source Sans Pro', ui-sans-serif, system-ui,
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
+    Arial, 'Noto Sans', sans-serif;
+  --qg-font-mono: 'IBM Plex Mono', ui-monospace, 'SFMono-Regular', Menlo,
+    Consolas, monospace;
+}
 
 @layer components {
   .qg-pill {
@@ -13,10 +24,122 @@
 }
 
 /* =====================================================================
- * Leaderboard table — Pyserini-2cr-inspired layout (.lb-* namespace).
- * Used by the home matrix and every per-X page. See
- * tmp/mockups/leaderboard-pyserini-style.html for the design source.
+ * Leaderboard — HuggingFace-style flat table (.lb-* namespace).
+ * Main index page: dataset-tab + retriever-pill selectors drive a
+ * single flat table (rank | method | model | metric1 | metric2).
+ * Per-X detail pages reuse shared primitives below.
  * ===================================================================== */
+
+/* ── Font family: Source Sans 3 matching HuggingFace / Gradio default theme ── */
+.lb-selector-card,
+.lb-filter-card,
+.lb-table-card,
+table.lb,
+.lb-exp-panel,
+.lb-exp-meta,
+.lb-exp-footer {
+  font-family: 'Source Sans 3', 'Source Sans Pro', ui-sans-serif, system-ui,
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
+    Arial, 'Noto Sans', sans-serif;
+}
+
+/* ---------- selector card (Dataset tabs + Retriever pills) ----------- */
+.lb-selector-card {
+  background: var(--qg-bg-soft);
+  border: 1px solid var(--qg-border);
+  border-radius: 12px;
+  padding: 12px 16px;
+  margin-bottom: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.lb-selector-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.lb-selector-label {
+  color: var(--qg-fg-muted);
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+  white-space: nowrap;
+  flex-shrink: 0;
+  min-width: 60px;
+}
+
+/* Dataset tabs — scrollable horizontal row */
+.lb-ds-tabs {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  overflow-x: auto;
+  scrollbar-width: none;
+  padding-bottom: 1px;
+}
+.lb-ds-tabs::-webkit-scrollbar { display: none; }
+
+.lb-ds-tab {
+  padding: 6px 15px;
+  border-radius: 999px;
+  border: 1px solid var(--qg-border);
+  background: var(--qg-bg);
+  color: var(--qg-fg-muted);
+  font-size: 15px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  user-select: none;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+.lb-ds-tab:hover:not(.active) {
+  border-color: var(--qg-accent);
+  color: var(--qg-fg);
+}
+.lb-ds-tab.active {
+  background: var(--qg-accent);
+  border-color: var(--qg-accent);
+  color: #fff;
+  font-weight: 600;
+}
+
+/* Retriever pills reuse .lb-chip (defined below) */
+.lb-ret-pills {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+/* Dataset dropdown (single-select <select>) */
+.lb-ds-select {
+  appearance: none;
+  -webkit-appearance: none;
+  background-color: var(--qg-bg);
+  border: 1px solid var(--qg-border);
+  border-radius: 8px;
+  color: var(--qg-fg);
+  font-family: inherit;
+  font-size: 15px;
+  font-weight: 500;
+  padding: 6px 32px 6px 13px;
+  cursor: pointer;
+  outline: none;
+  min-width: 160px;
+  max-width: 280px;
+  /* chevron arrow via inline SVG background */
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 9px center;
+  transition: border-color 0.15s;
+}
+.lb-ds-select:hover { border-color: var(--qg-accent); }
+.lb-ds-select:focus { border-color: var(--qg-accent); box-shadow: 0 0 0 2px rgba(236,72,153,0.15); }
+/* Dark mode: keep options readable */
+.lb-ds-select option { background: var(--qg-bg, #1a1d27); color: var(--qg-fg, #e2e8f0); }
 
 /* ---------- filter card -------------------------------------------------- */
 .lb-filter-card {
@@ -26,31 +149,769 @@
   padding: 12px 14px;
   margin-bottom: 12px;
 }
-.lb-filter-row { display: flex; flex-wrap: wrap; align-items: center; gap: 12px; row-gap: 10px; }
+.lb-filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  row-gap: 10px;
+}
 .lb-filter-row + .lb-filter-row {
-  margin-top: 10px; padding-top: 10px;
+  margin-top: 10px;
+  padding-top: 10px;
   border-top: 1px solid var(--qg-border-soft, var(--qg-border));
 }
-.lb-filter-group { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; }
+.lb-filter-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
 .lb-filter-label {
-  color: var(--qg-fg-muted); font-size: 10.5px;
-  text-transform: uppercase; letter-spacing: 0.06em;
-  font-weight: 600; margin-right: 1px;
+  color: var(--qg-fg-muted);
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+  margin-right: 1px;
 }
 
+/* Chip buttons (filter + retriever pills) */
 .lb-chip {
-  font-size: 11.5px; padding: 4px 9px; border-radius: 999px;
-  border: 1px solid var(--qg-border); color: var(--qg-fg);
-  background: var(--qg-bg); cursor: pointer; user-select: none;
+  font-size: 14.5px;
+  padding: 5px 11px;
+  border-radius: 999px;
+  border: 1px solid var(--qg-border);
+  color: var(--qg-fg);
+  background: var(--qg-bg);
+  cursor: pointer;
+  user-select: none;
   font-family: inherit;
   transition: background 0.15s, border-color 0.15s, color 0.15s;
 }
 .lb-chip:hover { border-color: var(--qg-accent); }
 .lb-chip.active {
-  background: var(--qg-accent); border-color: var(--qg-accent); color: #fff;
+  background: var(--qg-accent);
+  border-color: var(--qg-accent);
+  color: #fff;
 }
 
-/* multi-select dropdown (Datasets) */
+/* Search input */
+.lb-search-wrap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.lb-search-input {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--qg-bg);
+  border: 1px solid var(--qg-border);
+  border-radius: 8px;
+  padding: 5px 9px;
+  min-width: 240px;
+}
+.lb-search-input input {
+  background: transparent;
+  border: 0;
+  outline: 0;
+  color: var(--qg-fg);
+  font-size: 13px;
+  flex: 1;
+  font-family: inherit;
+}
+.lb-search-input svg { color: var(--qg-fg-muted); }
+.lb-row-count { font-size: 12px; color: var(--qg-fg-muted); white-space: nowrap; }
+
+/* Best-in-column legend */
+.lb-best-legend {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  color: var(--qg-fg-muted);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+.lb-best-legend .dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #d97706;
+  box-shadow: 0 0 5px rgba(217, 119, 6, 0.55);
+}
+[data-theme="dark"] .lb-best-legend .dot {
+  background: #fbbf24;
+  box-shadow: 0 0 5px rgba(251, 191, 36, 0.55);
+}
+
+/* ---------- table card --------------------------------------------------- */
+.lb-table-card {
+  background: var(--qg-bg-soft);
+  border: 1px solid var(--qg-border);
+  border-radius: 12px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+.lb-table-scroll {
+  flex: 1;
+  overflow: auto;
+  min-height: 0;
+  scrollbar-width: thin;
+  scrollbar-color: var(--qg-border) var(--qg-bg-soft);
+}
+.lb-table-scroll::-webkit-scrollbar { width: 9px; height: 9px; }
+.lb-table-scroll::-webkit-scrollbar-track { background: var(--qg-bg-soft); }
+.lb-table-scroll::-webkit-scrollbar-thumb {
+  background: var(--qg-border);
+  border-radius: 6px;
+}
+.lb-table-scroll::-webkit-scrollbar-thumb:hover { background: var(--qg-fg-muted); }
+
+/* ---------- flat leaderboard table (.lb.lb-flat) ------------------------- */
+table.lb.lb-flat {
+  width: 100%;
+  table-layout: fixed;
+}
+
+table.lb {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 15px;
+}
+
+table.lb.lb-flat thead th {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--qg-bg-softer, var(--qg-bg-soft));
+  color: var(--qg-fg-muted);
+  font-size: 14px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--qg-border);
+  white-space: nowrap;
+}
+
+/* Rank column */
+.lb-col-rank {
+  width: 52px;
+  min-width: 52px;
+  text-align: center;
+  padding-left: 8px !important;
+  padding-right: 8px !important;
+}
+
+/* Method column */
+.lb-col-method {
+  min-width: 120px;
+  max-width: 200px;
+}
+
+/* Model column */
+.lb-col-model {
+  min-width: 100px;
+  max-width: 180px;
+}
+
+/* Retriever column (shown when retriever filter = All) */
+.lb-col-retriever {
+  min-width: 90px;
+  font-weight: 500;
+  color: var(--qg-fg);
+  white-space: nowrap;
+}
+
+/* Flat table: distribute width evenly — avoid a large empty gap before metrics */
+table.lb.lb-flat .lb-col-rank {
+  width: 3.25rem;
+}
+table.lb.lb-flat thead th.lb-col-rank,
+table.lb.lb-flat tbody td.lb-col-rank {
+  text-align: center;
+  padding-left: 8px !important;
+  padding-right: 8px !important;
+}
+table.lb.lb-flat .lb-col-method {
+  width: 22%;
+  max-width: none;
+}
+table.lb.lb-flat .lb-col-model {
+  width: 26%;
+  max-width: none;
+}
+table.lb.lb-flat .lb-col-retriever {
+  width: 12%;
+  min-width: 6.5rem;
+  max-width: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+table.lb.lb-flat .lb-col-exp {
+  width: 2.5rem;
+}
+table.lb.lb-flat .lb-col-method,
+table.lb.lb-flat .lb-col-model,
+table.lb.lb-flat .lb-col-retriever {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Metric value columns */
+.lb-col-metric {
+  min-width: 110px;
+  text-align: center;
+  padding-left: 12px !important;
+  padding-right: 12px !important;
+  cursor: pointer;
+  user-select: none;
+  transition: color 0.15s;
+}
+
+/* Flat table: keep metric headers + values aligned (detail-page .lb thead th
+   rules below set text-align:left and would otherwise misalign headers). */
+table.lb.lb-flat thead th.lb-col-metric,
+table.lb.lb-flat tbody td.lb-col-metric {
+  text-align: center;
+  width: 14%;
+  min-width: 9.5rem;
+  max-width: none;
+  padding-left: 16px !important;
+  padding-right: 16px !important;
+}
+table.lb.lb-flat tbody td.lb-col-metric .metric-val {
+  display: inline-block;
+  width: 100%;
+  text-align: center;
+}
+.lb-col-metric:hover { color: var(--qg-fg); }
+
+/* Sortable header arrow */
+.lb-col-metric .name { display: inline-flex; align-items: center; justify-content: center; gap: 4px; }
+.lb-col-metric .arrow {
+  display: inline-block;
+  width: 9px;
+  text-align: center;
+  font-size: 10px;
+  visibility: hidden;
+  pointer-events: none;
+}
+.lb-col-metric.sort-asc .arrow,
+.lb-col-metric.sort-desc .arrow { visibility: visible; }
+.lb-col-metric.sort-asc,
+.lb-col-metric.sort-desc { color: var(--qg-accent); }
+.lb-col-metric.sort-asc  .arrow::after { content: "▲"; }
+.lb-col-metric.sort-desc .arrow::after { content: "▼"; }
+
+/* Expand button column */
+.lb-col-exp {
+  width: 36px;
+  min-width: 36px;
+  text-align: center;
+  padding: 0 8px !important;
+}
+
+/* ---------- table body rows ---------------------------------------------- */
+table.lb.lb-flat tbody td {
+  padding: 10px 12px;
+  border-top: 1px solid var(--qg-border-soft, var(--qg-border));
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+table.lb.lb-flat tbody tr.data:hover td {
+  background-color: var(--qg-row-hover, var(--qg-bg-soft));
+}
+table.lb.lb-flat tbody tr.data.expanded > td {
+  background-color: var(--qg-bg-soft);
+}
+
+/* Striped rows */
+table.lb.lb-flat tbody tr.data:nth-child(4n+1) td,
+table.lb.lb-flat tbody tr.data:nth-child(4n+2) td {
+  background-color: var(--qg-bg, transparent);
+}
+
+/* Rank badge */
+.lb-rank {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 26px;
+  height: 26px;
+  padding: 0 6px;
+  border-radius: 8px;
+  font-family: 'IBM Plex Mono', ui-monospace, Consolas, monospace;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+.lb-rank-1 {
+  background: #fef3c7;
+  color: #92400e;
+  border: 1px solid #fcd34d;
+}
+[data-theme="dark"] .lb-rank-1 {
+  background: rgba(251, 191, 36, 0.15);
+  color: #fbbf24;
+  border-color: rgba(251, 191, 36, 0.35);
+}
+.lb-rank-2 {
+  background: #f1f5f9;
+  color: #475569;
+  border: 1px solid #cbd5e1;
+}
+[data-theme="dark"] .lb-rank-2 {
+  background: rgba(148, 163, 184, 0.12);
+  color: #94a3b8;
+  border-color: rgba(148, 163, 184, 0.25);
+}
+.lb-rank-3 {
+  background: #fef0e7;
+  color: #92400e;
+  border: 1px solid #fdba74;
+}
+[data-theme="dark"] .lb-rank-3 {
+  background: rgba(180, 83, 9, 0.15);
+  color: #fb923c;
+  border-color: rgba(180, 83, 9, 0.35);
+}
+.lb-rank-n {
+  background: transparent;
+  color: var(--qg-fg-muted);
+  border: 1px solid transparent;
+  font-weight: 500;
+}
+
+/* Metric value cells */
+.lb-col-metric td,
+td.lb-col-metric {
+  text-align: center;
+  padding-left: 12px !important;
+  padding-right: 12px !important;
+}
+.metric-val {
+  font-family: 'IBM Plex Mono', ui-monospace, Consolas, monospace;
+  font-variant-numeric: tabular-nums;
+  font-size: 14px;
+  color: var(--qg-fg);
+}
+.metric-val.secondary {
+  color: var(--qg-fg-muted);
+  font-size: 13px;
+}
+td.lb-col-metric.best .metric-val {
+  color: #d97706;
+  font-weight: 700;
+}
+[data-theme="dark"] td.lb-col-metric.best .metric-val {
+  color: #fbbf24;
+  text-shadow: 0 0 6px rgba(251, 191, 36, 0.35);
+}
+
+.lb-method-name { font-weight: 600; color: var(--qg-fg); }
+
+/* ---------- method & model color badges ---------------------------------- */
+/* Base badge shape — used for both .lb-mtag-* and .lb-mdtag-* */
+.lb-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 9px;
+  border-radius: 7px;
+  font-size: 13px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  line-height: 1.6;
+}
+.lb-badge.lb-mono {
+  font-family: 'IBM Plex Mono', ui-monospace, Consolas, monospace;
+  font-size: 12.5px;
+  font-weight: 500;
+}
+
+/* --- Method palette (10 hues) --- */
+/* 0 violet */
+.lb-mtag-0 { background: hsl(258 70% 94%); color: hsl(258 55% 40%); border-color: hsl(258 55% 85%); }
+[data-theme="dark"] .lb-mtag-0 { background: hsl(258 45% 25% / 0.35); color: hsl(258 65% 75%); border-color: hsl(258 45% 45% / 0.4); }
+/* 1 sky */
+.lb-mtag-1 { background: hsl(200 85% 93%); color: hsl(200 75% 32%); border-color: hsl(200 65% 82%); }
+[data-theme="dark"] .lb-mtag-1 { background: hsl(200 60% 22% / 0.35); color: hsl(200 70% 68%); border-color: hsl(200 50% 40% / 0.4); }
+/* 2 emerald */
+.lb-mtag-2 { background: hsl(155 55% 91%); color: hsl(155 50% 28%); border-color: hsl(155 45% 78%); }
+[data-theme="dark"] .lb-mtag-2 { background: hsl(155 40% 20% / 0.35); color: hsl(155 55% 62%); border-color: hsl(155 40% 38% / 0.4); }
+/* 3 amber */
+.lb-mtag-3 { background: hsl(43 95% 90%); color: hsl(43 80% 28%); border-color: hsl(43 80% 76%); }
+[data-theme="dark"] .lb-mtag-3 { background: hsl(43 65% 22% / 0.35); color: hsl(43 85% 65%); border-color: hsl(43 60% 40% / 0.4); }
+/* 4 rose */
+.lb-mtag-4 { background: hsl(0 80% 94%); color: hsl(0 65% 38%); border-color: hsl(0 65% 82%); }
+[data-theme="dark"] .lb-mtag-4 { background: hsl(0 55% 25% / 0.35); color: hsl(0 70% 70%); border-color: hsl(0 50% 42% / 0.4); }
+/* 5 orange */
+.lb-mtag-5 { background: hsl(26 90% 92%); color: hsl(26 75% 32%); border-color: hsl(26 75% 80%); }
+[data-theme="dark"] .lb-mtag-5 { background: hsl(26 60% 22% / 0.35); color: hsl(26 80% 65%); border-color: hsl(26 55% 40% / 0.4); }
+/* 6 teal */
+.lb-mtag-6 { background: hsl(175 55% 90%); color: hsl(175 55% 26%); border-color: hsl(175 45% 76%); }
+[data-theme="dark"] .lb-mtag-6 { background: hsl(175 40% 20% / 0.35); color: hsl(175 55% 60%); border-color: hsl(175 38% 38% / 0.4); }
+/* 7 indigo */
+.lb-mtag-7 { background: hsl(231 65% 94%); color: hsl(231 55% 38%); border-color: hsl(231 55% 84%); }
+[data-theme="dark"] .lb-mtag-7 { background: hsl(231 45% 25% / 0.35); color: hsl(231 65% 72%); border-color: hsl(231 45% 44% / 0.4); }
+/* 8 lime */
+.lb-mtag-8 { background: hsl(78 55% 89%); color: hsl(78 50% 24%); border-color: hsl(78 45% 74%); }
+[data-theme="dark"] .lb-mtag-8 { background: hsl(78 40% 18% / 0.35); color: hsl(78 55% 58%); border-color: hsl(78 38% 36% / 0.4); }
+/* 9 fuchsia */
+.lb-mtag-9 { background: hsl(292 60% 93%); color: hsl(292 50% 36%); border-color: hsl(292 50% 82%); }
+[data-theme="dark"] .lb-mtag-9 { background: hsl(292 42% 24% / 0.35); color: hsl(292 60% 72%); border-color: hsl(292 42% 43% / 0.4); }
+
+/* --- Model palette (6 hues, distinct from method hues) --- */
+/* 0 blue — GPT-4.1 */
+.lb-mdtag-0 { background: hsl(214 80% 93%); color: hsl(214 70% 34%); border-color: hsl(214 65% 82%); }
+[data-theme="dark"] .lb-mdtag-0 { background: hsl(214 55% 23% / 0.35); color: hsl(214 70% 68%); border-color: hsl(214 50% 41% / 0.4); }
+/* 1 cyan — GPT-4.1-nano */
+.lb-mdtag-1 { background: hsl(187 65% 91%); color: hsl(187 60% 26%); border-color: hsl(187 55% 78%); }
+[data-theme="dark"] .lb-mdtag-1 { background: hsl(187 45% 20% / 0.35); color: hsl(187 60% 60%); border-color: hsl(187 40% 37% / 0.4); }
+/* 2 warm orange — Qwen-72B */
+.lb-mdtag-2 { background: hsl(32 85% 91%); color: hsl(32 72% 30%); border-color: hsl(32 70% 78%); }
+[data-theme="dark"] .lb-mdtag-2 { background: hsl(32 58% 21% / 0.35); color: hsl(32 75% 63%); border-color: hsl(32 52% 38% / 0.4); }
+/* 3 yellow/gold — Qwen-7B */
+.lb-mdtag-3 { background: hsl(50 90% 88%); color: hsl(50 75% 26%); border-color: hsl(50 78% 73%); }
+[data-theme="dark"] .lb-mdtag-3 { background: hsl(50 62% 20% / 0.35); color: hsl(50 82% 62%); border-color: hsl(50 58% 37% / 0.4); }
+/* 4 pink */
+.lb-mdtag-4 { background: hsl(317 60% 93%); color: hsl(317 50% 36%); border-color: hsl(317 50% 82%); }
+[data-theme="dark"] .lb-mdtag-4 { background: hsl(317 42% 23% / 0.35); color: hsl(317 58% 70%); border-color: hsl(317 40% 41% / 0.4); }
+/* 5 green */
+.lb-mdtag-5 { background: hsl(120 45% 90%); color: hsl(120 42% 26%); border-color: hsl(120 38% 76%); }
+[data-theme="dark"] .lb-mdtag-5 { background: hsl(120 35% 18% / 0.35); color: hsl(120 45% 58%); border-color: hsl(120 35% 35% / 0.4); }
+
+/* Hidden utility */
+.lb-hidden { display: none !important; }
+
+/* ---------- expand / collapse button -------------------------------------- */
+.lb-exp-btn {
+  position: relative;
+  width: 18px;
+  height: 18px;
+  border-radius: 5px;
+  background: var(--qg-bg-soft);
+  border: 1px solid var(--qg-border);
+  color: var(--qg-fg-muted);
+  cursor: pointer;
+  padding: 0;
+  transition: background 0.2s, border-color 0.2s, color 0.2s;
+}
+.lb-exp-btn:hover { color: var(--qg-fg); border-color: var(--qg-accent); }
+.lb-exp-btn::before,
+.lb-exp-btn::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 8px;
+  height: 1.5px;
+  background: currentColor;
+  border-radius: 1px;
+  transform: translate(-50%, -50%);
+  transition: transform 0.28s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.lb-exp-btn::after { transform: translate(-50%, -50%) rotate(90deg); }
+tr.expanded .lb-exp-btn {
+  background: var(--qg-accent);
+  border-color: var(--qg-accent);
+  color: #fff;
+}
+tr.expanded .lb-exp-btn::after { transform: translate(-50%, -50%) rotate(0deg); }
+
+/* ---------- expanded row panel -------------------------------------------- */
+.lb-exp-row > td {
+  padding: 0 !important;
+  background: var(--qg-bg) !important;
+  border-top: 0 !important;
+}
+.lb-exp-wrap {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.32s cubic-bezier(0.4, 0, 0.2, 1);
+  position: sticky;
+  left: 0;
+  width: var(--lb-vp-w, 100%);
+  max-width: var(--lb-vp-w, 100%);
+}
+.lb-exp-row.show .lb-exp-wrap { grid-template-rows: 1fr; }
+.lb-exp-wrap > .lb-exp-inner { overflow: hidden; min-height: 0; }
+.lb-exp-panel {
+  padding: 16px 20px 20px;
+  background: var(--qg-bg);
+  border-top: 1px solid var(--qg-border);
+  border-bottom: 1px solid var(--qg-border);
+  opacity: 0;
+  transform: translateY(-4px);
+  transition: opacity 0.22s ease 0.06s, transform 0.22s ease 0.06s;
+}
+.lb-exp-row.show .lb-exp-panel { opacity: 1; transform: translateY(0); }
+
+/* ── Two-column expand panel: commands (left) + bar chart (right) ── */
+.lb-exp-body {
+  display: grid;
+  grid-template-columns: 60% 40%;
+  gap: 20px;
+  align-items: start;
+}
+.lb-exp-commands {
+  min-width: 0;
+}
+
+/* Bar chart panel */
+.lb-exp-barchart-wrap {
+  background: var(--qg-bg-soft);
+  border: 1px solid var(--qg-border);
+  border-radius: 10px;
+  padding: 14px 16px;
+  min-width: 0;
+  margin-right: 16px;
+}
+.lb-barchart-title {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 700;
+  color: var(--qg-fg-muted);
+  margin-bottom: 14px;
+}
+.lb-bar-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  cursor: default;
+}
+.lb-bar-row:last-child { margin-bottom: 0; }
+.lb-bar-label {
+  font-size: 12px;
+  color: var(--qg-fg-muted);
+  width: 72px;
+  flex-shrink: 0;
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: color 0.15s, font-weight 0.15s;
+}
+.lb-bar-track {
+  flex: 1;
+  background: var(--qg-border);
+  border-radius: 4px;
+  height: 9px;
+  overflow: hidden;
+}
+.lb-bar {
+  height: 100%;
+  border-radius: 4px;
+  background: var(--qg-fg-muted);
+  opacity: 0.35;
+  transition: background 0.2s, opacity 0.2s, width 0.3s ease;
+}
+.lb-bar-val {
+  font-family: 'IBM Plex Mono', ui-monospace, Consolas, monospace;
+  font-size: 11.5px;
+  color: var(--qg-fg-muted);
+  width: 40px;
+  flex-shrink: 0;
+  text-align: right;
+  transition: color 0.15s;
+}
+/* Active (selected dataset) row */
+.lb-bar-row.active .lb-bar-label {
+  color: var(--qg-fg);
+  font-weight: 700;
+}
+.lb-bar-row.active .lb-bar {
+  background: var(--qg-accent);
+  opacity: 1;
+}
+.lb-bar-row.active .lb-bar-val {
+  color: var(--qg-accent);
+  font-weight: 700;
+}
+/* Responsive: stack vertically on narrow viewports */
+@media (max-width: 860px) {
+  .lb-exp-body {
+    grid-template-columns: 1fr;
+  }
+  .lb-exp-barchart-wrap {
+    border-top: 1px solid var(--qg-border);
+    border-radius: 10px;
+  }
+}
+
+.lb-exp-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--qg-fg-muted);
+  margin-bottom: 12px;
+}
+.lb-exp-meta .pill {
+  background: var(--qg-bg-soft);
+  border: 1px solid var(--qg-border);
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-family: 'IBM Plex Mono', ui-monospace, Consolas, monospace;
+  font-size: 12px;
+  color: var(--qg-fg);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.lb-exp-meta .pill strong {
+  color: var(--qg-fg-muted);
+  font-weight: 500;
+  text-transform: uppercase;
+  font-size: 11px;
+  letter-spacing: 0.05em;
+}
+
+/* Dataset tabs inside expand panel */
+.lb-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--qg-border);
+  margin-bottom: 14px;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--qg-border) transparent;
+}
+.lb-tab {
+  padding: 8px 13px;
+  font-size: 13.5px;
+  color: var(--qg-fg-muted);
+  cursor: pointer;
+  border: 0;
+  background: transparent;
+  border-bottom: 2px solid transparent;
+  white-space: nowrap;
+  font-family: inherit;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  transition: color 0.15s;
+}
+.lb-tab:hover { color: var(--qg-fg); }
+.lb-tab.active {
+  color: var(--qg-fg);
+  border-bottom-color: var(--qg-accent);
+}
+.lb-tab .score {
+  font-family: 'IBM Plex Mono', ui-monospace, Consolas, monospace;
+  font-size: 12px;
+  color: var(--qg-fg-muted);
+}
+.lb-tab.active .score { color: var(--qg-accent); }
+.lb-tab-pane { display: none; }
+.lb-tab-pane.active { display: block; }
+
+/* Code-step blocks */
+.lb-step {
+  background: var(--qg-bg-soft);
+  border: 1px solid var(--qg-border);
+  border-radius: 9px;
+  margin-bottom: 10px;
+  overflow: hidden;
+}
+.lb-step-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: var(--qg-bg-softer, var(--qg-bg-soft));
+  border-bottom: 1px solid var(--qg-border);
+}
+.lb-step-head .title {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--qg-fg);
+}
+.lb-step-head .num {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--qg-accent);
+  color: #fff;
+  font-size: 11.5px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.lb-step-head .hint {
+  color: var(--qg-fg-muted);
+  font-size: 12px;
+  font-weight: 400;
+  margin-left: 4px;
+}
+.lb-copy-btn {
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--qg-border);
+  background: var(--qg-bg);
+  color: var(--qg-fg-muted);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  transition: color 0.15s, border-color 0.15s;
+}
+.lb-copy-btn:hover { color: var(--qg-fg); border-color: var(--qg-accent); }
+.lb-copy-btn.copied { color: var(--qg-accent); border-color: var(--qg-accent); }
+.lb-step pre {
+  margin: 0;
+  padding: 12px 14px;
+  overflow-x: auto;
+  font-family: 'IBM Plex Mono', ui-monospace, Consolas, monospace;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--qg-fg);
+  scrollbar-width: thin;
+  scrollbar-color: var(--qg-border) transparent;
+}
+.lb-step pre::-webkit-scrollbar { height: 7px; }
+.lb-step pre::-webkit-scrollbar-thumb { background: var(--qg-border); border-radius: 6px; }
+.lb-step pre .flag { color: #a78bfa; }
+.lb-step pre .val  { color: #6ee7b7; }
+
+.lb-exp-footer {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin-top: 6px;
+  font-size: 12.5px;
+  color: var(--qg-fg-muted);
+  flex-wrap: wrap;
+}
+.lb-exp-footer a { color: var(--qg-accent); text-decoration: none; }
+.lb-exp-footer a:hover { text-decoration: underline; }
+
+/* ---------- per-X detail pages (datasets, methods, models, retrievers) ---
+   These pages still use the wider axis-column matrix layout and the dataset
+   multi-select dropdown + metric segmented control from the original design.
+   All styles below preserve those detail pages without change. */
+
+/* multi-select dropdown */
 .lb-multi { position: relative; }
 .lb-multi-trigger {
   display: inline-flex; align-items: center; gap: 7px;
@@ -109,6 +970,7 @@
   accent-color: var(--qg-accent);
   margin: 0; cursor: pointer;
 }
+.lb-multi-count { /* trigger label */ }
 
 /* segmented metric control */
 .lb-seg {
@@ -132,126 +994,85 @@
 .lb-seg-btn:hover:not(.active) { color: var(--qg-fg); background: var(--qg-bg-soft); }
 .lb-seg-btn.active { background: var(--qg-accent); color: #fff; }
 
-/* search input */
-.lb-search-wrap { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
-.lb-search-input {
-  display: flex; align-items: center; gap: 8px;
-  background: var(--qg-bg); border: 1px solid var(--qg-border);
-  border-radius: 8px; padding: 5px 9px; min-width: 240px;
-}
-.lb-search-input input {
-  background: transparent; border: 0; outline: 0; color: var(--qg-fg);
-  font-size: 12px; flex: 1; font-family: inherit;
-}
-.lb-search-input svg { color: var(--qg-fg-muted); }
-.lb-row-count { font-size: 11px; color: var(--qg-fg-muted); white-space: nowrap; }
-
-/* best-in-column legend */
-.lb-best-legend {
-  display: inline-flex; align-items: center; gap: 7px;
-  font-size: 11px; color: var(--qg-fg-muted);
-  letter-spacing: 0.02em; white-space: nowrap;
-}
-.lb-best-legend .dot {
-  width: 7px; height: 7px; border-radius: 50%;
-  background: var(--qg-accent);
-  box-shadow: 0 0 5px rgba(236,72,153,0.55);
-}
-
-/* ---------- table card ---------------------------------------------------
-   The card is sized by its flex parent (main) which fills the viewport.
-   It takes whatever vertical space remains after the filter card etc.
-   Inner scroll on both axes; sticky thead anchors to top:0 of the scroll
-   container; sticky axis cols anchor to its left. min-height:0 on the
-   scroll is the standard flex+overflow fix so it can actually shrink. */
-.lb-table-card {
-  background: var(--qg-bg-soft);
-  border: 1px solid var(--qg-border);
-  border-radius: 12px;
-  overflow: hidden;
-  display: flex; flex-direction: column;
-  flex: 1;
-  min-height: 0;
-}
-.lb-table-scroll {
-  flex: 1; overflow: auto;
-  min-height: 0;
-  scrollbar-width: thin;
-  scrollbar-color: var(--qg-border) var(--qg-bg-soft);
-}
-.lb-table-scroll::-webkit-scrollbar { width: 9px; height: 9px; }
-.lb-table-scroll::-webkit-scrollbar-track { background: var(--qg-bg-soft); }
-.lb-table-scroll::-webkit-scrollbar-thumb { background: var(--qg-border); border-radius: 6px; }
-.lb-table-scroll::-webkit-scrollbar-thumb:hover { background: var(--qg-fg-muted); }
-
-table.lb {
-  width: 100%; border-collapse: separate; border-spacing: 0; font-size: 12.5px;
-  --axis-w-1: 30px; --axis-w-2: 80px; --axis-w-3: 132px; --axis-w-4: 94px;
-}
-
-.lb thead th {
-  position: sticky;
-  z-index: 12;
-  background: var(--qg-bg-softer, var(--qg-bg-soft));
-  color: var(--qg-fg-muted);
-  font-size: 10.5px; font-weight: 600; text-transform: uppercase;
-  letter-spacing: 0.05em; text-align: left;
-  padding: 8px 8px;
-  border-bottom: 1px solid var(--qg-border);
-  white-space: nowrap;
-}
-/* Two-row sticky thead: top row at top:0, bot row stacked just below it.
-   Without the explicit offset, both rows would pin at top:0 and the bot row
-   (later in DOM) would paint over the top row. */
-.lb thead tr.top th { top: 0; padding-bottom: 6px; }
-.lb thead tr.bot th {
-  top: 28px;
-  padding-top: 7px; font-size: 10px; color: var(--qg-fg-muted);
-  border-bottom: 1px solid var(--qg-border); font-weight: 500;
-}
-.lb thead tr.top th.group {
-  text-align: center; color: var(--qg-fg);
-  border-left: 1px solid var(--qg-border-soft, var(--qg-border));
-}
-.lb thead tr.top th.group:first-of-type { border-left: 0; }
-/* center-align matches the value cells; padding-left:15 compensates for the
-   ~13px of right-side space reserved by the inline sort arrow, so the name's
-   visual centerline stays aligned with the value below it. (Scope is just
-   `.lb thead .metric` — works whether the metric th is in tr.top or tr.bot.) */
-.lb thead .metric {
-  text-align: center;
-  padding-left: 15px;
-}
-.lb thead .metric.first { border-left: 1px solid var(--qg-border-soft, var(--qg-border)); }
-.lb .hidden,
-.lb .lb-hide-ds,
-.lb .lb-hide-metric { display: none !important; }
-/* tabs/panes outside the .lb table also need these */
-.lb-hide-ds, .lb-hide-metric { display: none !important; }
-
-/* small count badge for axis col headers ("Method (10)") */
+/* Small count badge ("Method (10)") */
 .lb-count {
-  display: inline-flex; align-items: center; justify-content: center;
-  min-width: 16px; padding: 0 5px; height: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  padding: 0 5px;
+  height: 14px;
   margin-left: 5px;
   border-radius: 999px;
   background: var(--qg-bg);
   border: 1px solid var(--qg-border);
-  font-size: 9px; font-weight: 500;
+  font-size: 9px;
+  font-weight: 500;
   color: var(--qg-fg-muted);
   letter-spacing: 0;
   text-transform: none;
   vertical-align: middle;
 }
 
-/* sortable metric header — arrow always reserves 9px, visible only when sorted */
-.lb thead .metric { cursor: pointer; user-select: none; transition: color 0.15s; }
+/* Detail-page axis columns (sticky-left) */
+table.lb {
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 12.5px;
+  --axis-w-1: 30px;
+  --axis-w-2: 80px;
+  --axis-w-3: 132px;
+  --axis-w-4: 94px;
+}
+.lb thead th {
+  position: sticky;
+  z-index: 12;
+  background: var(--qg-bg-softer, var(--qg-bg-soft));
+  color: var(--qg-fg-muted);
+  font-size: 10.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  text-align: left;
+  padding: 8px 8px;
+  border-bottom: 1px solid var(--qg-border);
+  white-space: nowrap;
+}
+.lb thead tr.top th { top: 0; padding-bottom: 6px; }
+.lb thead tr.bot th {
+  top: 28px;
+  padding-top: 7px;
+  font-size: 10px;
+  color: var(--qg-fg-muted);
+  border-bottom: 1px solid var(--qg-border);
+  font-weight: 500;
+}
+.lb thead tr.top th.group {
+  text-align: center;
+  color: var(--qg-fg);
+  border-left: 1px solid var(--qg-border-soft, var(--qg-border));
+}
+.lb thead tr.top th.group:first-of-type { border-left: 0; }
+.lb thead .metric {
+  text-align: center;
+  padding-left: 15px;
+  cursor: pointer;
+  user-select: none;
+  transition: color 0.15s;
+}
 .lb thead .metric:hover { color: var(--qg-fg); }
+.lb thead .metric.first { border-left: 1px solid var(--qg-border-soft, var(--qg-border)); }
+.lb .hidden,
+.lb .lb-hide-ds,
+.lb .lb-hide-metric { display: none !important; }
+.lb-hide-ds, .lb-hide-metric { display: none !important; }
+
 .lb thead .metric .name { display: inline-block; }
 .lb thead .metric .arrow {
   display: inline-block;
   margin-left: 4px;
-  width: 9px; text-align: center;
+  width: 9px;
+  text-align: center;
   font-size: 9px;
   visibility: hidden;
   vertical-align: middle;
@@ -259,17 +1080,11 @@ table.lb {
 }
 .lb thead .metric.sort-asc .arrow,
 .lb thead .metric.sort-desc .arrow { visibility: visible; }
-.lb thead .metric.sort-asc, .lb thead .metric.sort-desc { color: var(--qg-accent); }
-.lb thead .metric.sort-asc  .arrow::after { content: '▲'; }
-.lb thead .metric.sort-desc .arrow::after { content: '▼'; }
+.lb thead .metric.sort-asc,
+.lb thead .metric.sort-desc { color: var(--qg-accent); }
+.lb thead .metric.sort-asc  .arrow::after { content: "▲"; }
+.lb thead .metric.sort-desc .arrow::after { content: "▼"; }
 
-/* sticky axis cols (width:1px + nowrap pins them to content width).
-   Z-index ladder:
-     thead axis intersection: 14 (covers everything when both scrolls move)
-     thead non-axis (datasets): 12 (from .lb thead th)
-     tbody axis (sticky-left):  11
-     tbody non-axis:            (auto, normal flow)
-*/
 .lb .ax {
   position: sticky;
   background: var(--qg-bg-softer, var(--qg-bg-soft));
@@ -277,7 +1092,6 @@ table.lb {
   width: 1px;
   white-space: nowrap;
 }
-/* corner cells (axis × thead): stick both ways, above all */
 .lb thead .ax { z-index: 14; }
 .lb tbody .ax { background: var(--qg-bg); }
 .lb tbody tr.data:hover .ax { background: var(--qg-row-hover, var(--qg-bg-soft)); }
@@ -287,7 +1101,8 @@ table.lb {
 .lb .ax-3 { left: calc(var(--axis-w-1) + var(--axis-w-2)); min-width: var(--axis-w-3); }
 .lb .ax-4 {
   left: calc(var(--axis-w-1) + var(--axis-w-2) + var(--axis-w-3));
-  min-width: var(--axis-w-4); border-right: 1px solid var(--qg-border);
+  min-width: var(--axis-w-4);
+  border-right: 1px solid var(--qg-border);
 }
 
 .lb tbody td {
@@ -298,9 +1113,10 @@ table.lb {
 .lb tbody tr.data:hover td { background-color: var(--qg-row-hover, var(--qg-bg-soft)); }
 .lb tbody tr.data.expanded > td { background-color: var(--qg-bg-soft); }
 
-/* metric value cells */
+/* Detail-page metric value cells */
 .lb-metric-cell {
-  text-align: center; font-family: 'JetBrains Mono', monospace;
+  text-align: center;
+  font-family: 'IBM Plex Mono', ui-monospace, Consolas, monospace;
   font-variant-numeric: tabular-nums;
   min-width: 68px;
 }
@@ -309,180 +1125,28 @@ table.lb {
 .lb-metric-cell .secondary { color: var(--qg-fg-muted); font-size: 11px; }
 table.lb.mode-single .lb-metric-cell .secondary { color: var(--qg-fg); font-size: 12.5px; }
 .lb-metric-cell.best .primary,
-.lb-metric-cell.best .secondary { color: var(--qg-accent); font-weight: 700; }
-table.lb.mode-single .lb-metric-cell.best .secondary { color: var(--qg-accent); font-weight: 700; }
+.lb-metric-cell.best .secondary { color: #d97706; font-weight: 700; }
+table.lb.mode-single .lb-metric-cell.best .secondary { color: #d97706; font-weight: 700; }
 [data-theme="dark"] .lb-metric-cell.best .primary,
-[data-theme="dark"] .lb-metric-cell.best .secondary { text-shadow: 0 0 6px rgba(236,72,153,0.35); }
+[data-theme="dark"] .lb-metric-cell.best .secondary { color: #fbbf24; text-shadow: 0 0 6px rgba(251, 191, 36, 0.35); }
 
 .lb-method-name { font-weight: 600; }
 
-/* expand/collapse button (15x15 plus/minus rotation) */
-.lb-exp-btn {
-  position: relative;
-  width: 15px; height: 15px;
-  border-radius: 4px;
-  background: var(--qg-bg-soft); border: 1px solid var(--qg-border);
-  color: var(--qg-fg-muted);
-  cursor: pointer;
-  padding: 0;
-  transition: background 0.2s, border-color 0.2s, color 0.2s;
-}
-.lb-exp-btn:hover { color: var(--qg-fg); border-color: var(--qg-accent); }
-.lb-exp-btn::before, .lb-exp-btn::after {
-  content: ''; position: absolute;
-  top: 50%; left: 50%;
-  width: 7px; height: 1.5px;
-  background: currentColor;
-  border-radius: 1px;
-  transform: translate(-50%, -50%);
-  transition: transform 0.28s cubic-bezier(.4,.0,.2,1);
-}
-.lb-exp-btn::after { transform: translate(-50%, -50%) rotate(90deg); }
-tr.expanded .lb-exp-btn {
-  background: var(--qg-accent); border-color: var(--qg-accent); color: #fff;
-}
-tr.expanded .lb-exp-btn::after { transform: translate(-50%, -50%) rotate(0deg); }
-
-/* expanded row panel — grid-rows transition for true height animation.
-   The td has full table width via colspan; we sticky-left the inner wrap
-   and clamp its width to the scroll-container's visible viewport (set as
-   --lb-vp-w in JS) so the panel stays in view regardless of horizontal
-   scroll, and DOES NOT extend the table's overall scroll width. */
-.lb-exp-row > td {
-  padding: 0 !important;
-  background: var(--qg-bg) !important;
-  border-top: 0 !important;
-}
-.lb-exp-wrap {
-  display: grid;
-  grid-template-rows: 0fr;
-  transition: grid-template-rows 0.32s cubic-bezier(.4,.0,.2,1);
-  position: sticky;
-  left: 0;
-  width: var(--lb-vp-w, 100%);
-  max-width: var(--lb-vp-w, 100%);
-}
-.lb-exp-row.show .lb-exp-wrap { grid-template-rows: 1fr; }
-.lb-exp-wrap > .lb-exp-inner { overflow: hidden; min-height: 0; }
-.lb-exp-panel {
-  padding: 16px 20px 20px;
-  background: var(--qg-bg);
-  border-top: 1px solid var(--qg-border);
-  border-bottom: 1px solid var(--qg-border);
-  opacity: 0;
-  transform: translateY(-4px);
-  transition: opacity 0.22s ease 0.06s, transform 0.22s ease 0.06s;
-}
-.lb-exp-row.show .lb-exp-panel { opacity: 1; transform: translateY(0); }
-
-.lb-exp-meta {
-  display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
-  font-size: 12px; color: var(--qg-fg-muted); margin-bottom: 12px;
-}
-.lb-exp-meta .pill {
-  background: var(--qg-bg-soft); border: 1px solid var(--qg-border);
-  padding: 3px 9px; border-radius: 999px; font-family: 'JetBrains Mono', monospace;
-  font-size: 11px; color: var(--qg-fg);
-  display: inline-flex; align-items: center; gap: 6px;
-}
-.lb-exp-meta .pill strong {
-  color: var(--qg-fg-muted); font-weight: 500;
-  text-transform: uppercase; font-size: 10px; letter-spacing: 0.05em;
-}
-
-/* tabs */
-.lb-tabs {
-  display: flex; gap: 0;
-  border-bottom: 1px solid var(--qg-border);
-  margin-bottom: 14px; overflow-x: auto;
-  scrollbar-width: thin; scrollbar-color: var(--qg-border) transparent;
-}
-.lb-tab {
-  padding: 8px 13px; font-size: 12.5px; color: var(--qg-fg-muted);
-  cursor: pointer; border: 0; background: transparent;
-  border-bottom: 2px solid transparent; white-space: nowrap;
-  font-family: inherit; font-weight: 500;
-  display: flex; align-items: center; gap: 7px;
-  transition: color 0.15s;
-}
-.lb-tab:hover { color: var(--qg-fg); }
-.lb-tab.active { color: var(--qg-fg); border-bottom-color: var(--qg-accent); }
-.lb-tab .score { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--qg-fg-muted); }
-.lb-tab.active .score { color: var(--qg-accent); }
-.lb-tab-pane { display: none; }
-.lb-tab-pane.active { display: block; }
-
-/* code-step blocks */
-.lb-step {
-  background: var(--qg-bg-soft);
-  border: 1px solid var(--qg-border);
-  border-radius: 9px;
-  margin-bottom: 10px;
-  overflow: hidden;
-}
-.lb-step-head {
-  display: flex; align-items: center; justify-content: space-between;
-  padding: 8px 12px; background: var(--qg-bg-softer, var(--qg-bg-soft));
-  border-bottom: 1px solid var(--qg-border);
-}
-.lb-step-head .title {
-  display: flex; align-items: center; gap: 9px;
-  font-size: 12px; font-weight: 600; color: var(--qg-fg);
-}
-.lb-step-head .num {
-  width: 18px; height: 18px; border-radius: 999px;
-  background: var(--qg-accent); color: #fff; font-size: 10.5px; font-weight: 700;
-  display: inline-flex; align-items: center; justify-content: center;
-}
-.lb-step-head .hint {
-  color: var(--qg-fg-muted); font-size: 11px; font-weight: 400; margin-left: 4px;
-}
-.lb-copy-btn {
-  font-family: inherit; font-size: 11px; font-weight: 500;
-  padding: 4px 8px; border-radius: 6px;
-  border: 1px solid var(--qg-border); background: var(--qg-bg);
-  color: var(--qg-fg-muted); cursor: pointer;
-  display: inline-flex; align-items: center; gap: 5px;
-  transition: color 0.15s, border-color 0.15s;
-}
-.lb-copy-btn:hover { color: var(--qg-fg); border-color: var(--qg-accent); }
-.lb-copy-btn.copied { color: var(--qg-accent); border-color: var(--qg-accent); }
-.lb-step pre {
-  margin: 0; padding: 12px 14px; overflow-x: auto;
-  font-family: 'JetBrains Mono', monospace; font-size: 11.5px; line-height: 1.55;
-  color: var(--qg-fg);
-  scrollbar-width: thin; scrollbar-color: var(--qg-border) transparent;
-}
-.lb-step pre::-webkit-scrollbar { height: 7px; }
-.lb-step pre::-webkit-scrollbar-thumb { background: var(--qg-border); border-radius: 6px; }
-.lb-step pre .flag { color: #a78bfa; }
-.lb-step pre .val  { color: #6ee7b7; }
-
-.lb-exp-footer {
-  display: flex; gap: 10px; align-items: center;
-  margin-top: 6px; font-size: 11.5px; color: var(--qg-fg-muted);
-  flex-wrap: wrap;
-}
-.lb-exp-footer a { color: var(--qg-accent); text-decoration: none; }
-.lb-exp-footer a:hover { text-decoration: underline; }
-
-/* responsive */
-@media (max-width: 1280px) {
-  table.lb { --axis-w-2: 76px; --axis-w-3: 122px; --axis-w-4: 88px; }
-  .lb-metric-cell { min-width: 62px; }
-  .lb-metric-cell.metric-primary { min-width: 74px; }
-}
-@media (max-width: 1100px) {
-  table.lb { font-size: 12px; }
-  .lb-metric-cell { min-width: 58px; }
-  .lb-metric-cell.metric-primary { min-width: 68px; }
-  .lb tbody td, .lb thead th { padding: 6px 6px; }
-}
+/* ---------- responsive ---------------------------------------------------- */
 @media (max-width: 900px) {
+  .lb-ds-tabs { flex-wrap: nowrap; }
+  .lb-selector-row { flex-wrap: wrap; }
   .lb .ax { position: static; }
   .lb .ax-4 { border-right: 0; }
   .lb-table-card { height: auto; }
   .lb-filter-row { gap: 12px; }
   .lb-search-wrap { margin-left: 0; width: 100%; }
   .lb-search-input { min-width: 0; flex: 1; }
+  .lb-col-model { display: none; }
+}
+@media (max-width: 640px) {
+  .lb-ds-tab { font-size: 13px; padding: 5px 11px; }
+  .lb-selector-label { min-width: 50px; font-size: 12px; }
+  .lb-filter-label { font-size: 12px; }
+  .lb-chip { font-size: 13px; padding: 4px 9px; }
 }


### PR DESCRIPTION
## Summary
- Replace crowded wide matrix with flat table driven by benchmark, dataset, and retriever selectors
- Add LLM/method filter chips, retriever column when "All" is selected, and expand-row reproduce commands
- Add per-dataset bar chart beside commands in the expand panel (60/40 layout)
- Use gold for best-in-column values (distinct from pink selection state); default dataset DL 2019

## Test plan
- [ ] Confirm default load: MS MARCO + DL 2019 + Retriever All
- [ ] Expand a row: commands + bar chart visible; active dataset tab scrolls into view
- [ ] Switch dataset tabs: bar highlight and commands update
- [ ] Select a specific retriever: retriever column hides
- [ ] Check light and dark mode