### PR TITLE
Use full BRIGHT subset names on the leaderboard

### DIFF
--- a/dataset_registry.yaml
+++ b/dataset_registry.yaml
@@ -244,7 +244,7 @@ datasets:
       eval_metrics: ["ndcg_cut.10", "recall.100", "recall.1000"]
 
   bright-aops:
-    name: "BRIGHT — AOPS"
+    name: "BRIGHT — AoPS"
     index: {name: "bright-aops"}
     topics: {name: "bright-aops"}
     qrels:  {name: "bright-aops"}

--- a/reproducibility/site/src/pages/index.astro
+++ b/reproducibility/site/src/pages/index.astro
@@ -22,14 +22,19 @@ const SHORT: Record<string, string> = {
   "msmarco-v1-passage.trecdl2019": "DL 2019",
   "msmarco-v1-passage.trecdl2020": "DL 2020",
   "msmarco-v1-passage.dlhard":     "DL-HARD",
-  // BRIGHT
-  "bright-biology":           "Biology",
-  "bright-earth-science":     "Earth Sci.",
-  "bright-economics":         "Economics",
-  "bright-psychology":        "Psychology",
-  "bright-robotics":          "Robotics",
-  "bright-stackoverflow":     "StackOverflow",
-  "bright-sustainable-living":"Sustain. Living",
+  // BRIGHT (official subset names, no "BRIGHT —" prefix)
+  "bright-biology":             "Biology",
+  "bright-earth-science":       "Earth Science",
+  "bright-economics":           "Economics",
+  "bright-psychology":          "Psychology",
+  "bright-robotics":            "Robotics",
+  "bright-stackoverflow":       "Stack Overflow",
+  "bright-sustainable-living":  "Sustainable Living",
+  "bright-pony":                "Pony",
+  "bright-leetcode":            "LeetCode",
+  "bright-aops":                "AoPS",
+  "bright-theoremqa-theorems":  "TheoremQA Theorems",
+  "bright-theoremqa-questions": "TheoremQA Questions",
 };
 
 const METRIC_LABEL: Record<string, string> = {


### PR DESCRIPTION
## Summary
BRIGHT subsets without runs rendered with the registry's `"BRIGHT — …"` prefix on the leaderboard (e.g. **"BRIGHT — AOPS"**, "BRIGHT — LeetCode"), and the three with runs used cramped abbreviations.

**Root cause** — display-layer only, not data:
- The leaderboard `SHORT` label map only covered the 7 BRIGHT subsets that have runs. The other 5 (aops, leetcode, pony, theoremqa-theorems/questions) fell back to `dataset_registry.yaml`'s `name`, which carries the intended `"BRIGHT — "` prefix → it leaked onto the page.
- The registry display name `"BRIGHT — AOPS"` had the wrong casing.

The raw results carry only the slug `dataset_id` (`bright-aops`, …) — no display name — so nothing in `reproducibility/data/runs/` or `results.csv` is affected or changed.

## Changes
- `index.astro` — complete the `SHORT` map for all 12 BRIGHT subsets with official names; de-abbreviate the three holdovers (Earth Science, Sustainable Living, Stack Overflow). The single-dataset table no longer needs short column labels.
- `dataset_registry.yaml` — `"BRIGHT — AOPS"` → `"BRIGHT — AoPS"`.

Runless subsets intentionally remain visible as placeholder datasets (per maintainer preference).

## Test plan
- [x] Leaderboard build passes
- [x] All 12 BRIGHT labels render with no "BRIGHT —" prefix
- [x] Spot-check the BRIGHT dataset dropdown in light + dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)