### PR TITLE
Cite pages: full author names + published DBLP BibTeX (+Hai Son Le); about page BRIGHT

### DIFF
--- a/reproducibility/site/src/pages/about.astro
+++ b/reproducibility/site/src/pages/about.astro
@@ -19,7 +19,8 @@ gh pr create`;
   <section class="prose prose-slate mt-4 max-w-3xl text-qg-fg-muted">
     <p>
       The QueryGym Leaderboard tracks reproducible query-reformulation results
-      across IR benchmarks (BEIR, MS MARCO, TREC DL). Every row is backed by a
+      across IR benchmarks (MS MARCO / TREC Deep Learning, BEIR, and BRIGHT).
+      Every row is backed by a
       JSON file conforming to <code class="qg-mono">reproducibility/schema.json</code> v1.
       Submissions may also include the reformulated-queries TSV and a
       TREC-format <code class="qg-mono">.run.txt</code> for full re-evaluation; both are optional.

--- a/reproducibility/site/src/pages/cite.astro
+++ b/reproducibility/site/src/pages/cite.astro
@@ -43,14 +43,14 @@ const sigirBibtex = `@inproceedings{querygym2026reproducibility,
       <CitationCard
         title="QueryGym: A Toolkit for Reproducible LLM-Based Query Reformulation"
         venue="WWW 2026 — Demos"
-        authors="Bigdeli, Hamidi Rad, Incesu, Arabzadeh, Clarke, Bagheri"
+        authors="Amin Bigdeli, Radin Hamidi Rad, Mert Incesu, Negar Arabzadeh, Charles L. A. Clarke, Ebrahim Bagheri"
         bibtex={wwwBibtex}
         url="https://arxiv.org/abs/2511.15996"
       />
       <CitationCard
         title="A Reproducibility Study of LLM-Based Query Reformulation"
         venue="SIGIR 2026 — Reproducibility Track"
-        authors="Bigdeli, Hamidi Rad, Incesu, Arabzadeh, Clarke, Bagheri"
+        authors="Amin Bigdeli, Radin Hamidi Rad, Mert Incesu, Negar Arabzadeh, Charles L. A. Clarke, Ebrahim Bagheri"
         bibtex={sigirBibtex}
         url="https://arxiv.org/abs/2604.27421"
       />

--- a/reproducibility/site/src/pages/cite.astro
+++ b/reproducibility/site/src/pages/cite.astro
@@ -2,27 +2,27 @@
 import Default from "../layouts/Default.astro";
 import CitationCard from "../components/CitationCard.astro";
 
-const wwwBibtex = `@misc{bigdeli2025querygymtoolkitreproduciblellmbased,
-  title={QueryGym: A Toolkit for Reproducible LLM-Based Query Reformulation},
+const wwwBibtex = `@inproceedings{DBLP:conf/www/BigdeliRIACB26,
   author={Amin Bigdeli and Radin Hamidi Rad and Mert Incesu and Negar Arabzadeh and Charles L. A. Clarke and Ebrahim Bagheri},
-  year={2025},
-  eprint={2511.15996},
-  archivePrefix={arXiv},
-  primaryClass={cs.IR},
-  url={https://arxiv.org/abs/2511.15996},
+  title={QueryGym: {A} Toolkit for Reproducible LLM-Based Query Reformulation},
+  booktitle={Companion Proceedings of the ACM Web Conference 2026, WWW Companion 2026, Dubai, United Arab Emirates, 29 June 2026 - 3 July 2026},
+  pages={196--199},
+  publisher={ACM},
+  year={2026},
+  url={https://doi.org/10.1145/3774905.3793135},
+  doi={10.1145/3774905.3793135},
 }`;
 
-const sigirBibtex = `@inproceedings{querygym2026reproducibility,
+const sigirBibtex = `@article{DBLP:journals/corr/abs-2604-27421,
+  author={Amin Bigdeli and Radin Hamidi Rad and Hai Son Le and Mert Incesu and Negar Arabzadeh and Charles L. A. Clarke and Ebrahim Bagheri},
   title={A Reproducibility Study of LLM-Based Query Reformulation},
-  author={Amin Bigdeli and Radin Hamidi Rad and Mert Incesu and Negar Arabzadeh and Charles L. A. Clarke and Ebrahim Bagheri},
-  booktitle={Proceedings of the 49th International ACM SIGIR Conference on Research and Development in Information Retrieval},
-  series={SIGIR '26},
+  journal={CoRR},
+  volume={abs/2604.27421},
   year={2026},
-  note={Reproducibility Track},
+  url={https://doi.org/10.48550/arXiv.2604.27421},
+  doi={10.48550/ARXIV.2604.27421},
+  eprinttype={arXiv},
   eprint={2604.27421},
-  archivePrefix={arXiv},
-  primaryClass={cs.IR},
-  url={https://arxiv.org/abs/2604.27421},
 }`;
 ---
 
@@ -50,7 +50,7 @@ const sigirBibtex = `@inproceedings{querygym2026reproducibility,
       <CitationCard
         title="A Reproducibility Study of LLM-Based Query Reformulation"
         venue="SIGIR 2026 — Reproducibility Track"
-        authors="Amin Bigdeli, Radin Hamidi Rad, Mert Incesu, Negar Arabzadeh, Charles L. A. Clarke, Ebrahim Bagheri"
+        authors="Amin Bigdeli, Radin Hamidi Rad, Hai Son Le, Mert Incesu, Negar Arabzadeh, Charles L. A. Clarke, Ebrahim Bagheri"
         bibtex={sigirBibtex}
         url="https://arxiv.org/abs/2604.27421"
       />

--- a/web/site/src/pages/cite.astro
+++ b/web/site/src/pages/cite.astro
@@ -83,14 +83,14 @@ const jsonLd = JSON.stringify({
       <CitationCard
         title="QueryGym: A Toolkit for Reproducible LLM-Based Query Reformulation"
         venue="WWW 2026 — Demos"
-        authors="Bigdeli, Hamidi Rad, Incesu, Arabzadeh, Clarke, Bagheri"
+        authors="Amin Bigdeli, Radin Hamidi Rad, Mert Incesu, Negar Arabzadeh, Charles L. A. Clarke, Ebrahim Bagheri"
         bibtex={wwwBibtex}
         url="https://arxiv.org/abs/2511.15996"
       />
       <CitationCard
         title="A Reproducibility Study of LLM-Based Query Reformulation"
         venue="SIGIR 2026 — Reproducibility Track"
-        authors="Bigdeli, Hamidi Rad, Incesu, Arabzadeh, Clarke, Bagheri"
+        authors="Amin Bigdeli, Radin Hamidi Rad, Mert Incesu, Negar Arabzadeh, Charles L. A. Clarke, Ebrahim Bagheri"
         bibtex={sigirBibtex}
         url="https://arxiv.org/abs/2604.27421"
       />

--- a/web/site/src/pages/cite.astro
+++ b/web/site/src/pages/cite.astro
@@ -2,35 +2,45 @@
 import Default from "../layouts/Default.astro";
 import CitationCard from "../components/CitationCard.astro";
 
-const wwwBibtex = `@misc{bigdeli2025querygymtoolkitreproduciblellmbased,
-  title={QueryGym: A Toolkit for Reproducible LLM-Based Query Reformulation},
+const wwwBibtex = `@inproceedings{DBLP:conf/www/BigdeliRIACB26,
   author={Amin Bigdeli and Radin Hamidi Rad and Mert Incesu and Negar Arabzadeh and Charles L. A. Clarke and Ebrahim Bagheri},
-  year={2025},
-  eprint={2511.15996},
-  archivePrefix={arXiv},
-  primaryClass={cs.IR},
-  url={https://arxiv.org/abs/2511.15996},
+  title={QueryGym: {A} Toolkit for Reproducible LLM-Based Query Reformulation},
+  booktitle={Companion Proceedings of the ACM Web Conference 2026, WWW Companion 2026, Dubai, United Arab Emirates, 29 June 2026 - 3 July 2026},
+  pages={196--199},
+  publisher={ACM},
+  year={2026},
+  url={https://doi.org/10.1145/3774905.3793135},
+  doi={10.1145/3774905.3793135},
 }`;
 
-const sigirBibtex = `@inproceedings{querygym2026reproducibility,
+const sigirBibtex = `@article{DBLP:journals/corr/abs-2604-27421,
+  author={Amin Bigdeli and Radin Hamidi Rad and Hai Son Le and Mert Incesu and Negar Arabzadeh and Charles L. A. Clarke and Ebrahim Bagheri},
   title={A Reproducibility Study of LLM-Based Query Reformulation},
-  author={Amin Bigdeli and Radin Hamidi Rad and Mert Incesu and Negar Arabzadeh and Charles L. A. Clarke and Ebrahim Bagheri},
-  booktitle={Proceedings of the 49th International ACM SIGIR Conference on Research and Development in Information Retrieval},
-  series={SIGIR '26},
+  journal={CoRR},
+  volume={abs/2604.27421},
   year={2026},
-  note={Reproducibility Track},
+  url={https://doi.org/10.48550/arXiv.2604.27421},
+  doi={10.48550/ARXIV.2604.27421},
+  eprinttype={arXiv},
   eprint={2604.27421},
-  archivePrefix={arXiv},
-  primaryClass={cs.IR},
-  url={https://arxiv.org/abs/2604.27421},
 }`;
 
 // JSON-LD: two ScholarlyArticle entries (WWW Demos + SIGIR Reproducibility).
 // Search engines use these to surface the papers as research artifacts in
 // scholar-aware results.
-const sharedAuthors = [
+const wwwAuthors = [
   { "@type": "Person", name: "Amin Bigdeli" },
   { "@type": "Person", name: "Radin Hamidi Rad" },
+  { "@type": "Person", name: "Mert Incesu" },
+  { "@type": "Person", name: "Negar Arabzadeh" },
+  { "@type": "Person", name: "Charles L. A. Clarke" },
+  { "@type": "Person", name: "Ebrahim Bagheri" },
+];
+// The reproducibility paper adds Hai Son Le (3rd author); the toolkit paper does not.
+const sigirAuthors = [
+  { "@type": "Person", name: "Amin Bigdeli" },
+  { "@type": "Person", name: "Radin Hamidi Rad" },
+  { "@type": "Person", name: "Hai Son Le" },
   { "@type": "Person", name: "Mert Incesu" },
   { "@type": "Person", name: "Negar Arabzadeh" },
   { "@type": "Person", name: "Charles L. A. Clarke" },
@@ -48,7 +58,7 @@ const jsonLd = JSON.stringify({
       inLanguage: "en",
       isAccessibleForFree: true,
       publisher: { "@type": "Organization", name: "arXiv" },
-      author: sharedAuthors,
+      author: wwwAuthors,
     },
     {
       "@type": "ScholarlyArticle",
@@ -59,7 +69,7 @@ const jsonLd = JSON.stringify({
       inLanguage: "en",
       isAccessibleForFree: true,
       publisher: { "@type": "Organization", name: "arXiv" },
-      author: sharedAuthors,
+      author: sigirAuthors,
     },
   ],
 });
@@ -90,7 +100,7 @@ const jsonLd = JSON.stringify({
       <CitationCard
         title="A Reproducibility Study of LLM-Based Query Reformulation"
         venue="SIGIR 2026 — Reproducibility Track"
-        authors="Amin Bigdeli, Radin Hamidi Rad, Mert Incesu, Negar Arabzadeh, Charles L. A. Clarke, Ebrahim Bagheri"
+        authors="Amin Bigdeli, Radin Hamidi Rad, Hai Son Le, Mert Incesu, Negar Arabzadeh, Charles L. A. Clarke, Ebrahim Bagheri"
         bibtex={sigirBibtex}
         url="https://arxiv.org/abs/2604.27421"
       />


### PR DESCRIPTION
## Summary
Citation and about-page corrections across both sites.

**Cite pages (marketing + leaderboard):**
- Show **full author names** under each paper title (was last-names-only, which read oddly).
- **WWW toolkit paper** → published DBLP `@inproceedings` (WWW Companion 2026, pages 196–199, DOI), trimmed of DBLP-only fields (timestamp/biburl/bibsource). Stays 6 authors.
- **Reproducibility paper** → DBLP `@article` (CoRR), trimmed. Adds the new author **Hai Son Le** (3rd) → 7 authors, applied to the BibTeX, the card author line, and the marketing site's JSON-LD (split from the previously shared author list so the toolkit paper keeps its six).

**Leaderboard about page:**
- Benchmark list now includes **BRIGHT** (was "BEIR, MS MARCO, TREC DL"). Other claims on that page (submit commands, schema v1, run-path layout) were verified still accurate.

## Notes
- The WWW JSON-LD `datePublished` stays `2025-11-20` because that entry models the arXiv artifact (`publisher: arXiv`, arXiv URL), distinct from the 2026 conference BibTeX.

## Test plan
- [x] Both sites build clean
- [x] SIGIR card + BibTeX show 7 authors (Hai Son Le 3rd); WWW shows 6
- [x] Both DBLP keys render; JSON-LD author lists split correctly
- [x] Eyeball both cite pages + leaderboard about in light/dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)